### PR TITLE
add plot_trace

### DIFF
--- a/src/arviz_plots/plots/__init__.py
+++ b/src/arviz_plots/plots/__init__.py
@@ -2,4 +2,6 @@
 
 from .posteriorplot import plot_posterior
 
-__all__ = ["plot_posterior"]
+from .traceplot import plot_trace
+
+__all__ = ["plot_posterior", "plot_trace"]

--- a/src/arviz_plots/plots/traceplot.py
+++ b/src/arviz_plots/plots/traceplot.py
@@ -1,0 +1,118 @@
+"""Trace plot code."""
+from arviz_base import rcParams
+from arviz_base.labels import BaseLabeller
+from arviz_base.utils import _var_names
+
+from arviz_plots.plot_collection import PlotCollection
+from arviz_plots.plots.utils import filter_aes
+from arviz_plots.visuals import (
+    labelled_title,
+    line,
+)
+
+
+def plot_trace(
+    dt,
+    var_names=None,
+    filter_vars=None,
+    sample_dims=None,
+    plot_collection=None,
+    backend=None,
+    labeller=None,
+    aes_map=None,
+    plot_kwargs=None,
+    pc_kwargs=None,
+):
+    """Plot iteration versus sampled values.
+
+    Parameters
+    ----------
+    dt : DataTree
+        Input data
+    var_names: str or list of str, optional
+        One or more variables to be plotted.
+        Prefix the variables by ~ when you want to exclude them from the plot.
+    filter_vars: {None, “like”, “regex”}, optional, default=None
+        If None (default), interpret var_names as the real variables names.
+        If “like”, interpret var_names as substrings of the real variables names.
+        If “regex”, interpret var_names as regular expressions on the real variables names.
+    sample_dims : iterable, optional
+        Dimensions to reduce unless mapped to an aesthetic.
+        Defaults to ``rcParams["data.sample_dims"]``
+    plot_collection : PlotCollection, optional
+    backend : {"matplotlib", "bokeh"}, optional
+    labeller : labeller, optional
+    aes_map : mapping, optional
+        Mapping of artists to aesthetics that should use their mapping in `plot_collection`
+        when plotted. Defaults to only mapping properties to the density representation.
+    plot_kwargs : mapping, optional
+        Valid keys are:
+
+        * trace -> passed to visuals.line
+        * divergence -> passed to visuals.line_x
+
+    pc_kwargs : mapping
+        Passed to :class:`arviz_plots.PlotCollection`
+
+    Returns
+    -------
+    PlotCollection
+    """
+    if sample_dims is None:
+        sample_dims = rcParams["data.sample_dims"]
+    if plot_kwargs is None:
+        plot_kwargs = {}
+    if pc_kwargs is None:
+        pc_kwargs = {}
+    else:
+        pc_kwargs = pc_kwargs.copy()
+
+    var_names =  _var_names(var_names, dt.posterior.ds, filter_vars)
+
+    if var_names is None:
+        posterior = dt.posterior.ds
+    else:
+        posterior = dt.posterior.ds[var_names]
+
+    pc_kwargs.setdefault("aes", {"color": ["chain"]})
+
+    if plot_collection is None:
+        if backend is None:
+            backend = rcParams["plot.backend"]
+        pc_kwargs.setdefault("col_wrap", 5)
+        pc_kwargs.setdefault(
+            "cols", ["__variable__"] + [dim for dim in posterior.dims if dim not in sample_dims]
+        )
+        plot_collection = PlotCollection.wrap(
+            posterior,
+            backend=backend,
+            **pc_kwargs,
+        )
+
+    if aes_map is None:
+        aes_map = {"trace": plot_collection.aes_set}
+    if labeller is None:
+        labeller = BaseLabeller()
+
+    # trace
+    _, _, density_ignore = filter_aes(plot_collection, aes_map, "trace", sample_dims)
+    plot_collection.map(
+        line, "trace", data=posterior, ignore_aes=density_ignore, **plot_kwargs.get("trace", {})
+    )
+
+    # aesthetics
+    _, title_aes, title_ignore = filter_aes(plot_collection, aes_map, "title", sample_dims)
+    title_kwargs = plot_kwargs.get("title", {}).copy()
+    if "color" not in title_aes:
+        title_kwargs.setdefault("color", "black")
+    plot_collection.map(
+        labelled_title,
+        "title",
+        ignore_aes=title_ignore,
+        subset_info=True,
+        labeller=labeller,
+        **title_kwargs,
+    )
+
+
+    return plot_collection

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -3,6 +3,7 @@
 from importlib import import_module
 
 import xarray as xr
+import numpy as np
 
 
 def line_xy(da, target, backend, **kwargs):
@@ -21,6 +22,12 @@ def line_x(da, target, backend, y=None, **kwargs):
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
     return plot_backend.line(da, y, target, **kwargs)
 
+def line(da, target, backend, **kwargs):
+    """Plot a line along the y axis with x being the range of len(y)."""
+
+    values = da.values.flatten()
+    plot_backend = import_module(f"arviz_plots.backend.{backend}")
+    return plot_backend.line(np.arange(len(values)), values, target, **kwargs)
 
 def scatter_x(da, target, backend, y=None, **kwargs):
     """Plot a dot/rug/scatter along the x axis (y constant)."""

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -4,7 +4,9 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from arviz_plots import plot_posterior
+from arviz_base import load_arviz_data
+
+from arviz_plots import plot_posterior, plot_trace
 
 
 @pytest.fixture(scope="module")
@@ -17,6 +19,11 @@ def data(seed=31):
         {"mu": (["chain", "draw"], mu), "theta": (["chain", "draw", "hierarchy"], theta)},
     )
 
+@pytest.fixture(scope="module")
+def datatree():
+    return load_arviz_data("centered_eight")
+
+
 
 @pytest.mark.parametrize("backend", ["matplotlib", "bokeh"])
 class TestPlots:
@@ -28,3 +35,10 @@ class TestPlots:
         assert "hierarchy" in pc.viz["theta"].dims
         assert "hierarchy" not in pc.viz["mu"]["point_estimate"].dims
         assert "hierarchy" in pc.viz["theta"]["point_estimate"].dims
+
+
+    def test_plot_trace(self, datatree, backend):
+        pc = plot_trace(datatree, var_names=["mu"], backend=backend)
+        assert "/mu" in pc.aes.groups
+        assert "/theta" not in pc.aes.groups
+        assert pc.viz["mu"].trace.shape == (4,)


### PR DESCRIPTION
This follows the decision that `plot_trace` will be a plot without the densities (kde or histograms).

I started with this example because it seems simple enough to get familiar with the code. Please let me know what I am doing wrong. 

Also not sure what should I do to add divergences, given that divergences are defined in a separate group.

This is how the default plots look like for the `centered_eight` dataset

![default](https://github.com/arviz-devs/arviz-plots/assets/1338958/b08d5e0c-8e91-4dd0-929f-dbade50abf7b)

and this is with some customization 

plot_trace(post, var_names=["mu", "tau"], 
                    sample_dims=["draw"],
                    pc_kwargs={"plot_grid_kws": {"figsize": (12, 7), "sharey":"row"}, "col_wrap":4})


![customized](https://github.com/arviz-devs/arviz-plots/assets/1338958/c40558ed-a228-48e2-9404-5042fce9bb00)
                    
                    
                    