### PR TITLE
[WIP] Add plot_trace_dens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ instance/
 docs/_build/
 docs/build
 docs/source/api/generated
+docs/jupyter_execute
 
 # PyBuilder
 .pybuilder/

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -3,23 +3,27 @@
 ## Batteries included plots
 
 ```{eval-rst}
+.. currentmodule:: arviz_plots
+
 .. autosummary::
    :toctree: generated/
 
-   arviz_plots.plot_dist
-   arviz_plots.plot_trace
+   plot_dist
+   plot_trace
 ```
 
 
 ## Base facetting and aesthetics mapping class
 
 ```{eval-rst}
+.. currentmodule:: arviz_plots
+
 .. autosummary::
    :toctree: generated/
 
-   arviz_plots.PlotCollection
-   arviz_plots.PlotCollection.grid
-   arviz_plots.PlotCollection.map
-   arviz_plots.PlotCollection.show
-   arviz_plots.PlotCollection.wrap
+   PlotCollection
+   PlotCollection.grid
+   PlotCollection.map
+   PlotCollection.show
+   PlotCollection.wrap
 ```

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -10,6 +10,7 @@
 
    plot_dist
    plot_trace
+   plot_trace_dist
 ```
 
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -17,7 +17,7 @@ Plotting backends have to be added manually.
 :hidden:
 :caption: Example notebooks
 
-tutorials/intro_to_plotmuseum
+tutorials/intro_to_plotcollection
 tutorials/plot_dist_examples
 ```
 

--- a/src/arviz_plots/__init__.py
+++ b/src/arviz_plots/__init__.py
@@ -6,10 +6,10 @@ import os
 
 _log = logging.getLogger(__name__)
 
-from ._version import __version__
+from arviz_plots._version import __version__
 
-from .plot_collection import PlotCollection
-from .plots import *
+from arviz_plots.plot_collection import PlotCollection
+from arviz_plots.plots import *
 
 
 if not logging.root.handlers:

--- a/src/arviz_plots/__init__.py
+++ b/src/arviz_plots/__init__.py
@@ -301,9 +301,11 @@ try:
         _mpl_cm("gray", _linear_grey_10_95_c0)
         _mpl_cm("gray_r", list(reversed(_linear_grey_10_95_c0)))
 
+    del LinearSegmentedColormap, mpl
+
 except ImportError:
     pass
 
 
 # clean namespace
-del os, logging, LinearSegmentedColormap, mpl
+del os, logging

--- a/src/arviz_plots/backend/matplotlib/__init__.py
+++ b/src/arviz_plots/backend/matplotlib/__init__.py
@@ -165,15 +165,18 @@ def title(string, target, *, size=unset, color=unset, **artist_kws):
     kwargs = {"fontsize": size, "color": color}
     return target.set_title(string, **_filter_kwargs(kwargs, Text, artist_kws))
 
+
 def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
     """Interface to matplotlib for adding a title to a plot."""
     kwargs = {"fontsize": size, "color": color}
     return target.set_ylabel(string, **_filter_kwargs(kwargs, Text, artist_kws))
 
+
 def xlabel(string, target, *, size=unset, color=unset, **artist_kws):
     """Interface to matplotlib for adding a title to a plot."""
     kwargs = {"fontsize": size, "color": color}
     return target.set_xlabel(string, **_filter_kwargs(kwargs, Text, artist_kws))
+
 
 def remove_ticks(target, axis="y"):
     """Interface to matplotlib for removing axis from a plot."""
@@ -184,6 +187,7 @@ def remove_ticks(target, axis="y"):
     elif axis == "both":
         target.xaxis.set_ticks([])
         target.yaxis.set_ticks([])
+
 
 def remove_axis(target, axis="y"):
     """Interface to matplotlib for removing axis from a plot."""

--- a/src/arviz_plots/backend/matplotlib/__init__.py
+++ b/src/arviz_plots/backend/matplotlib/__init__.py
@@ -165,6 +165,25 @@ def title(string, target, *, size=unset, color=unset, **artist_kws):
     kwargs = {"fontsize": size, "color": color}
     return target.set_title(string, **_filter_kwargs(kwargs, Text, artist_kws))
 
+def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
+    """Interface to matplotlib for adding a title to a plot."""
+    kwargs = {"fontsize": size, "color": color}
+    return target.set_ylabel(string, **_filter_kwargs(kwargs, Text, artist_kws))
+
+def xlabel(string, target, *, size=unset, color=unset, **artist_kws):
+    """Interface to matplotlib for adding a title to a plot."""
+    kwargs = {"fontsize": size, "color": color}
+    return target.set_xlabel(string, **_filter_kwargs(kwargs, Text, artist_kws))
+
+def remove_ticks(target, axis="y"):
+    """Interface to matplotlib for removing axis from a plot."""
+    if axis == "y":
+        target.yaxis.set_ticks([])
+    elif axis == "x":
+        target.xaxis.set_ticks([])
+    elif axis == "both":
+        target.xaxis.set_ticks([])
+        target.yaxis.set_ticks([])
 
 def remove_axis(target, axis="y"):
     """Interface to matplotlib for removing axis from a plot."""

--- a/src/arviz_plots/backend/matplotlib/__init__.py
+++ b/src/arviz_plots/backend/matplotlib/__init__.py
@@ -178,6 +178,11 @@ def xlabel(string, target, *, size=unset, color=unset, **artist_kws):
     return target.set_xlabel(string, **_filter_kwargs(kwargs, Text, artist_kws))
 
 
+def ticks_size(value, target):
+    """Interface to matplotlib for setting ticks size."""
+    target.tick_params(axis="both", labelsize=value)
+
+
 def remove_ticks(target, axis="y"):
     """Interface to matplotlib for removing axis from a plot."""
     if axis == "y":

--- a/src/arviz_plots/plots/__init__.py
+++ b/src/arviz_plots/plots/__init__.py
@@ -1,7 +1,7 @@
 """Batteries-included ArviZ plots."""
 
 from .distplot import plot_dist
-from .traceplot import plot_trace
 from .tracedensplot import plot_trace_dens
+from .traceplot import plot_trace
 
 __all__ = ["plot_dist", "plot_trace", "plot_trace_dens"]

--- a/src/arviz_plots/plots/__init__.py
+++ b/src/arviz_plots/plots/__init__.py
@@ -2,5 +2,6 @@
 
 from .distplot import plot_dist
 from .traceplot import plot_trace
+from .tracedensplot import plot_trace_dens
 
-__all__ = ["plot_dist", "plot_trace"]
+__all__ = ["plot_dist", "plot_trace", "plot_trace_dens"]

--- a/src/arviz_plots/plots/__init__.py
+++ b/src/arviz_plots/plots/__init__.py
@@ -1,7 +1,7 @@
 """Batteries-included ArviZ plots."""
 
 from .distplot import plot_dist
-from .tracedensplot import plot_trace_dens
+from .tracedistplot import plot_trace_dist
 from .traceplot import plot_trace
 
-__all__ = ["plot_dist", "plot_trace", "plot_trace_dens"]
+__all__ = ["plot_dist", "plot_trace", "plot_trace_dist"]

--- a/src/arviz_plots/plots/tracedensplot.py
+++ b/src/arviz_plots/plots/tracedensplot.py
@@ -96,7 +96,7 @@ def plot_trace_dens(
 
     figsize, textsize, linewidth = scale_fig_size(
         pc_kwargs.get("plot_grid_kws", {}).get("figsize", None),
-        rows=get_size_of_var(posterior, compact=compact),
+        rows=get_size_of_var(posterior, compact=compact, sample_dims=sample_dims),
         cols=2,
     )
 
@@ -175,7 +175,7 @@ def plot_trace_dens(
             ignore_aes=yticks_dens_ignore,
             coords={"__column__": 0},
             store_artist=False,
-            axis="y", # maybe also be explicit here?
+            axis="y",  # maybe also be explicit here?
         )
 
     # Add varnames as x and y labels

--- a/src/arviz_plots/plots/tracedensplot.py
+++ b/src/arviz_plots/plots/tracedensplot.py
@@ -1,0 +1,203 @@
+"""TraceDens plot code."""
+from arviz_base import rcParams
+from arviz_base.labels import BaseLabeller
+from arviz_base.utils import _var_names
+
+from arviz_plots.plot_collection import PlotCollection
+from arviz_plots.plots.utils import filter_aes
+from arviz_plots.visuals import labelled_x, labelled_y, remove_ticks, line, line_xy, ecdf_line
+
+
+def plot_trace_dens(
+    dt,
+    var_names=None,
+    filter_vars=None,
+    sample_dims=None,
+    compact=True,
+    kind=None,
+    plot_collection=None,
+    backend=None,
+    labeller=None,
+    aes_map=None,
+    dens_kwargs=None,
+    trace_kwargs=None,
+    pc_kwargs=None,
+):
+    """Plot 1D marginal densities on the first row and iteration versus sampled
+    values on the second.
+
+    Parameters
+    ----------
+    dt : DataTree
+        Input data
+    var_names: str or list of str, optional
+        One or more variables to be plotted.
+        Prefix the variables by ~ when you want to exclude them from the plot.
+    filter_vars: {None, “like”, “regex”}, optional, default=None
+        If None (default), interpret var_names as the real variables names.
+        If “like”, interpret var_names as substrings of the real variables names.
+        If “regex”, interpret var_names as regular expressions on the real variables names.
+    sample_dims : iterable, optional
+        Dimensions to reduce unless mapped to an aesthetic.
+        Defaults to ``rcParams["data.sample_dims"]``
+    compact: bool, optional
+        Plot multidimensional variables in a single plot. Defaults to True
+    kind : {"kde", "hist", "dot", "ecdf"}, optional
+        How to represent the marginal density.
+    plot_collection : PlotCollection, optional
+    backend : {"matplotlib", "bokeh"}, optional
+    labeller : labeller, optional
+    aes_map : mapping, optional
+        Mapping of artists to aesthetics that should use their mapping in `plot_collection`
+        when plotted. Defaults to only mapping properties to the density representation.
+    trace_kwargs : mapping, optional
+        Valid keys are:
+
+        * trace -> passed to visuals.line
+        * divergence -> passed to visuals.line_x
+
+    pc_kwargs : mapping
+        Passed to :class:`arviz_plots.PlotCollection`
+
+    Returns
+    -------
+    PlotCollection
+    """
+    if sample_dims is None:
+        sample_dims = rcParams["data.sample_dims"]
+    if kind is None:
+        kind = rcParams["plot.density_kind"]
+    if dens_kwargs is None:
+        dens_kwargs = {}
+    if trace_kwargs is None:
+        trace_kwargs = {}
+    if pc_kwargs is None:
+        pc_kwargs = {}
+    else:
+        pc_kwargs = pc_kwargs.copy()
+
+    var_names = _var_names(var_names, dt.posterior.ds, filter_vars)
+
+    if var_names is None:
+        posterior = dt.posterior.ds
+    else:
+        posterior = dt.posterior.ds[var_names]
+
+    pc_kwargs.setdefault("aes", {"color": ["chain"]})
+
+    aux_dim_list = [dim for dim in posterior.dims if dim not in {"chain", "draw"}]
+
+    if plot_collection is None:
+        if backend is None:
+            backend = rcParams["plot.backend"]
+        pc_kwargs.setdefault("cols", ["__column__"])
+
+        if compact:
+            pc_kwargs.setdefault("rows", ["__variable__"])
+        else:
+            pc_kwargs.setdefault("rows", ["__variable__"]+aux_dim_list)
+
+        plot_collection = PlotCollection.grid(
+           posterior.expand_dims(__column__=2),
+            backend=backend,
+            **pc_kwargs,
+        )
+
+    if aes_map is None:
+        aes_map = {"trace": plot_collection.aes_set}
+
+    if labeller is None:
+        labeller = BaseLabeller()
+
+    density_dims, _, density_ignore = filter_aes(plot_collection, aes_map, "trace", sample_dims)
+    
+    if compact:
+        density_dims += aux_dim_list
+
+
+    # dens
+    if kind == "kde":
+        density = posterior.azstats.kde(dims=density_dims, **dens_kwargs.get("density", {}))
+        plot_collection.map(
+            line_xy, "dens", data=density, ignore_aes=density_ignore, coords={"__column__": 0}, **trace_kwargs.get("dens", {})
+        )
+
+    elif kind == "ecdf":
+        density = posterior.azstats.ecdf(dims=density_dims, **dens_kwargs.get("density", {}))
+        plot_collection.map(
+            ecdf_line, "dens", data=density, ignore_aes=density_ignore, coords={"__column__": 0}, **trace_kwargs.get("dens", {}),
+        )
+
+    # trace
+    plot_collection.map(
+        line, "trace", data=posterior, ignore_aes=density_ignore,  coords={"__column__": 1}, **trace_kwargs.get("trace", {})
+    )
+
+    # aesthetics
+    if kind == "kde":
+        _, _, yticks_dens_ignore = filter_aes(plot_collection, aes_map, "yticks_dens", sample_dims)
+        yticks_dens_kwargs = dens_kwargs.get("yticks_dens", {}).copy()
+
+        plot_collection.map(
+            remove_ticks,
+            "yticks_dens",
+            ignore_aes=yticks_dens_ignore,
+            coords={"__column__": 0},
+            **yticks_dens_kwargs,
+        )
+
+    _, xlabel_dens_aes, xlabel_dens_ignore = filter_aes(plot_collection, aes_map, "xlabel_dens", sample_dims)
+    xlabel_dens_kwargs = dens_kwargs.get("xlabel_dens", {}).copy()
+
+    if "color" not in xlabel_dens_aes:
+        xlabel_dens_kwargs.setdefault("color", "black")
+        #xlabel_dens_kwargs.setdefault("fontsize", "5")
+    
+    plot_collection.map(
+        labelled_x,
+        "xlabel_dens",
+        ignore_aes=xlabel_dens_ignore,
+        coords={"__column__": 0},
+        subset_info=True,
+        labeller=labeller,
+        **xlabel_dens_kwargs,
+    )
+
+    _, xlabel_trace_aes, xlabel_trace_ignore = filter_aes(plot_collection, aes_map, "xlabel_trace", sample_dims)
+    xlabel_trace_kwargs = dens_kwargs.get("xlabel_trace", {}).copy()
+
+    if "color" not in xlabel_trace_aes:
+        xlabel_trace_kwargs.setdefault("color", "black")
+        #xlabel_trace_kwargs.setdefault("fontsize", "5")
+    
+    plot_collection.map(
+        labelled_x,
+        "xlabel_trace",
+        ignore_aes=xlabel_trace_ignore,
+        coords={"__column__": 1},
+        subset_info=True,
+        labeller=labeller,
+        text="Steps",
+        **xlabel_trace_kwargs,
+    )
+
+    _, ylabel_trace_aes, ylabel_trace_ignore = filter_aes(plot_collection, aes_map, "ylabel_trace", sample_dims)
+    ylabel_trace_kwargs = trace_kwargs.get("ylabel_trace", {}).copy()
+
+    if "color" not in ylabel_trace_aes:
+        ylabel_trace_kwargs.setdefault("color", "black")
+        #ylabel_trace_kwargs.setdefault("fontsize", "5")
+    
+    plot_collection.map(
+        labelled_y,
+        "xlabel_dens",
+        ignore_aes=ylabel_trace_ignore,
+        coords={"__column__": 1},
+        subset_info=True,
+        labeller=labeller,
+        **ylabel_trace_kwargs,
+    )
+
+
+
+    return plot_collection

--- a/src/arviz_plots/plots/tracedensplot.py
+++ b/src/arviz_plots/plots/tracedensplot.py
@@ -174,6 +174,8 @@ def plot_trace_dens(
             "yticks_dens",
             ignore_aes=yticks_dens_ignore,
             coords={"__column__": 0},
+            store_artist=False,
+            axis="y", # maybe also be explicit here?
         )
 
     # Add varnames as x and y labels

--- a/src/arviz_plots/plots/tracedensplot.py
+++ b/src/arviz_plots/plots/tracedensplot.py
@@ -92,7 +92,7 @@ def plot_trace_dens(
 
     pc_kwargs.setdefault("aes", {"color": ["chain"]})
 
-    aux_dim_list = [dim for dim in posterior.dims if dim not in {"chain", "draw"}]
+    aux_dim_list = [dim for dim in posterior.dims if dim not in sample_dims]
 
     figsize, textsize, linewidth = scale_fig_size(
         pc_kwargs.get("plot_grid_kws", {}).get("figsize", None),

--- a/src/arviz_plots/plots/tracedistplot.py
+++ b/src/arviz_plots/plots/tracedistplot.py
@@ -1,4 +1,4 @@
-"""TraceDens plot code."""
+"""TraceDist plot code."""
 from arviz_base import rcParams
 from arviz_base.labels import BaseLabeller
 from arviz_base.utils import _var_names
@@ -16,7 +16,7 @@ from arviz_plots.visuals import (
 )
 
 
-def plot_trace_dens(
+def plot_trace_dist(
     dt,
     var_names=None,
     filter_vars=None,
@@ -27,11 +27,11 @@ def plot_trace_dens(
     backend=None,
     labeller=None,
     aes_map=None,
-    dens_kwargs=None,
+    dist_kwargs=None,
     plot_kwargs=None,
     pc_kwargs=None,
 ):
-    """Plot 1D marginal densities and iteration versus sampled values.
+    """Plot 1D marginal distributions and iteration versus sampled values.
 
     Parameters
     ----------
@@ -50,13 +50,13 @@ def plot_trace_dens(
     compact: bool, optional
         Plot multidimensional variables in a single plot. Defaults to True
     kind : {"kde", "hist", "dot", "ecdf"}, optional
-        How to represent the marginal density.
+        How to represent the marginal distribution.
     plot_collection : PlotCollection, optional
     backend : {"matplotlib", "bokeh"}, optional
     labeller : labeller, optional
     aes_map : mapping, optional
         Mapping of artists to aesthetics that should use their mapping in `plot_collection`
-        when plotted. Defaults to only mapping properties to the density representation.
+        when plotted. Defaults to only mapping properties to the distribution representation.
     plot_kwargs : mapping, optional
         Valid keys are:
 
@@ -74,8 +74,8 @@ def plot_trace_dens(
         sample_dims = rcParams["data.sample_dims"]
     if kind is None:
         kind = rcParams["plot.density_kind"]
-    if dens_kwargs is None:
-        dens_kwargs = {}
+    if dist_kwargs is None:
+        dist_kwargs = {}
     if plot_kwargs is None:
         plot_kwargs = {}
     if pc_kwargs is None:
@@ -100,7 +100,7 @@ def plot_trace_dens(
         cols=2,
     )
 
-    plot_kwargs.setdefault("dens", {}).setdefault("lw", linewidth)
+    plot_kwargs.setdefault("dist", {}).setdefault("lw", linewidth)
     plot_kwargs.setdefault("trace", {}).setdefault("lw", linewidth)
 
     if plot_collection is None:
@@ -133,25 +133,25 @@ def plot_trace_dens(
 
     # dens
     if kind == "kde":
-        density = posterior.azstats.kde(dims=density_dims, **dens_kwargs.get("density", {}))
+        density = posterior.azstats.kde(dims=density_dims, **dist_kwargs.get("density", {}))
         plot_collection.map(
             line_xy,
-            "dens",
+            "dist",
             data=density,
             ignore_aes=density_ignore,
             coords={"__column__": 0},
-            **plot_kwargs.get("dens", {}),
+            **plot_kwargs.get("dist", {}),
         )
 
     elif kind == "ecdf":
-        density = posterior.azstats.ecdf(dims=density_dims, **dens_kwargs.get("density", {}))
+        density = posterior.azstats.ecdf(dims=density_dims, **dist_kwargs.get("density", {}))
         plot_collection.map(
             ecdf_line,
-            "dens",
+            "dist",
             data=density,
             ignore_aes=density_ignore,
             coords={"__column__": 0},
-            **plot_kwargs.get("dens", {}),
+            **plot_kwargs.get("dist", {}),
         )
 
     # trace
@@ -167,63 +167,66 @@ def plot_trace_dens(
     ## aesthetics
     # Remove yticks, only for KDEs
     if kind == "kde":
-        _, _, yticks_dens_ignore = filter_aes(plot_collection, aes_map, "yticks_dens", sample_dims)
+        _, _, yticks_dist_ignore = filter_aes(plot_collection, aes_map, "yticks_dist", sample_dims)
 
         plot_collection.map(
             remove_ticks,
-            "yticks_dens",
-            ignore_aes=yticks_dens_ignore,
+            "yticks_dist",
+            ignore_aes=yticks_dist_ignore,
             coords={"__column__": 0},
             store_artist=False,
             axis="y",  # maybe also be explicit here?
         )
 
     # Add varnames as x and y labels
-    _, labels_dens_aes, labels_dens_ignore = filter_aes(
-        plot_collection, aes_map, "labels_dens", sample_dims
+    _, labels_dist_aes, labels_dist_ignore = filter_aes(
+        plot_collection, aes_map, "labels_dist", sample_dims
     )
-    labels_dens_kwargs = dens_kwargs.get("labels_dens", {}).copy()
+    labels_dist_kwargs = dist_kwargs.get("labels_dist", {}).copy()
 
-    if "color" not in labels_dens_aes:
-        labels_dens_kwargs.setdefault("color", "black")
+    if "color" not in labels_dist_aes:
+        labels_dist_kwargs.setdefault("color", "black")
 
-    labels_dens_kwargs.setdefault("fontsize", textsize)
+    labels_dist_kwargs.setdefault("fontsize", textsize)
 
     plot_collection.map(
         labelled_x,
-        "labels_dens",
-        ignore_aes=labels_dens_ignore,
+        "label_x_dist",
+        ignore_aes=labels_dist_ignore,
         coords={"__column__": 0},
         subset_info=True,
         labeller=labeller,
-        **labels_dens_kwargs,
+        store_artist=False,
+        **labels_dist_kwargs,
     )
 
     plot_collection.map(
         labelled_y,
-        "labels_dens",
-        ignore_aes=labels_dens_ignore,
+        "label_y_dist",
+        ignore_aes=labels_dist_ignore,
         coords={"__column__": 1},
         subset_info=True,
         labeller=labeller,
-        **labels_dens_kwargs,
+        store_artist=False,
+        **labels_dist_kwargs,
     )
 
     # Adjust ticks size
     plot_collection.map(
         ticks_size,
-        "labels_dens",
-        ignore_aes=labels_dens_ignore,
+        "ticks_size",
+        ignore_aes=labels_dist_ignore,
         subset_info=True,
         value=textsize,
-        **labels_dens_kwargs,
+        store_artist=False,
+        **labels_dist_kwargs,
     )
 
     # Add "Steps" as x_label for trace
     _, xlabel_trace_aes, xlabel_trace_ignore = filter_aes(
         plot_collection, aes_map, "xlabel_trace", sample_dims
     )
-    xlabel_plot_kwargs = dens_kwargs.get("xlabel_trace", {}).copy()
+    xlabel_plot_kwargs = dist_kwargs.get("xlabel_trace", {}).copy()
 
     if "color" not in xlabel_trace_aes:
         xlabel_plot_kwargs.setdefault("color", "black")

--- a/src/arviz_plots/plots/utils.py
+++ b/src/arviz_plots/plots/utils.py
@@ -23,7 +23,7 @@ def filter_aes(pc, aes_map, artist, sample_dims):
 
 def get_size_of_var(group, compact=False):
     """Get the size of the variables in a group."""
-    coords = group.coords._names - {"chain", "draw"}  # pylint: disable=protected-access
+    coords = set(group.sizes) - set(sample_dims)
     var_size = 0
     for var in group.data_vars:
         dims_size = group[var].sizes

--- a/src/arviz_plots/plots/utils.py
+++ b/src/arviz_plots/plots/utils.py
@@ -63,7 +63,7 @@ def scale_fig_size(figsize, rows=1, cols=1):
     """
     # we should read figsize from rcParams or bokeh theme
     if figsize is None:
-        width, height = 8, 2
+        width = 8
         height = (rows + 1) ** 1.1
     else:
         width, height = figsize

--- a/src/arviz_plots/plots/utils.py
+++ b/src/arviz_plots/plots/utils.py
@@ -21,7 +21,7 @@ def filter_aes(pc, aes_map, artist, sample_dims):
     return artist_dims, artist_aes, ignore_aes
 
 
-def get_size_of_var(group, compact=False):
+def get_size_of_var(group, compact=False, sample_dims=None):
     """Get the size of the variables in a group."""
     coords = set(group.sizes) - set(sample_dims)
     var_size = 0

--- a/src/arviz_plots/plots/utils.py
+++ b/src/arviz_plots/plots/utils.py
@@ -19,3 +19,60 @@ def filter_aes(pc, aes_map, artist, sample_dims):
     _, all_loop_dims = pc.update_aes(ignore_aes=ignore_aes)
     artist_dims = [dim for dim in sample_dims if dim not in all_loop_dims]
     return artist_dims, artist_aes, ignore_aes
+
+
+def get_size_of_var(group, compact=False):
+    """Get the size of the variables in a group."""
+    coords = group.coords._names - {"chain", "draw"}  # pylint: disable=protected-access
+    var_size = 0
+    for var in group.data_vars:
+        dims_size = group[var].sizes
+        partial_sum = 1
+        if not compact:
+            for key in coords:
+                if key in dims_size:
+                    partial_sum *= dims_size[key]
+
+        var_size += partial_sum
+
+    return var_size
+
+
+def scale_fig_size(figsize, rows=1, cols=1):
+    """Scale figure properties according to figsize, rows and cols.
+
+    Parameters
+    ----------
+    figsize : float or None
+        Size of figure in inches
+    textsize : float or None
+        fontsize
+    rows : int
+        Number of rows
+    cols : int
+        Number of columns
+
+    Returns
+    -------
+    figsize : float or None
+        Size of figure in inches
+    labelsize : int
+        fontsize for labels
+    linewidth : int
+        linewidth
+    """
+    # we should read figsize from rcParams or bokeh theme
+    if figsize is None:
+        width, height = 8, 2
+        height = (rows + 1) ** 1.1
+    else:
+        width, height = figsize
+
+    # we should read textsize from rcParams or bokeh theme
+    textsize = 14
+    val = (width * height) ** 0.5
+    val2 = (cols * rows) ** 0.5
+    labelsize = textsize * (val / 4) / val2
+    linewidth = labelsize / 10
+
+    return (width, height), labelsize, linewidth

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -78,13 +78,21 @@ def labelled_title(da, target, backend, *, labeller, var_name, sel, isel, **kwar
 
 
 def labelled_y(da, target, backend, *, labeller, var_name, sel, isel, **kwargs):
+    """Add a y label to a plot using an ArviZ labeller."""
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
     return plot_backend.ylabel(labeller.make_label_vert(var_name, sel, isel), target, **kwargs)
 
 
 def labelled_x(da, target, backend, *, labeller, var_name, sel, isel, **kwargs):
+    """Add a x label to a plot using an ArviZ labeller."""
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
     return plot_backend.xlabel(labeller.make_label_vert(var_name, sel, isel), target, **kwargs)
+
+
+def ticks_size(da, target, backend, *, value, **kwargs):
+    """Set the size of ticks."""
+    plot_backend = import_module(f"arviz_plots.backend.{backend}")
+    return plot_backend.ticks_size(value, target)
 
 
 def remove_axis(da, target, backend, **kwargs):

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -77,7 +77,21 @@ def labelled_title(da, target, backend, *, labeller, var_name, sel, isel, **kwar
     return plot_backend.title(labeller.make_label_vert(var_name, sel, isel), target, **kwargs)
 
 
+def labelled_y(da, target, backend, *, labeller, var_name, sel, isel, **kwargs):
+    plot_backend = import_module(f"arviz_plots.backend.{backend}")
+    return plot_backend.ylabel(labeller.make_label_vert(var_name, sel, isel), target, **kwargs)
+
+def labelled_x(da, target, backend, *, labeller, var_name, sel, isel, **kwargs):
+    plot_backend = import_module(f"arviz_plots.backend.{backend}")
+    return plot_backend.xlabel(labeller.make_label_vert(var_name, sel, isel), target, **kwargs)
+
+
 def remove_axis(da, target, backend, **kwargs):
     """Dispatch to ``remove_axis`` function in backend."""
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
     plot_backend.remove_axis(target, **kwargs)
+
+def remove_ticks(da, target, backend, **kwargs):
+    """Dispatch to ``remove_axis`` function in backend."""
+    plot_backend = import_module(f"arviz_plots.backend.{backend}")
+    plot_backend.remove_ticks(target, **kwargs)

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -81,6 +81,7 @@ def labelled_y(da, target, backend, *, labeller, var_name, sel, isel, **kwargs):
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
     return plot_backend.ylabel(labeller.make_label_vert(var_name, sel, isel), target, **kwargs)
 
+
 def labelled_x(da, target, backend, *, labeller, var_name, sel, isel, **kwargs):
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
     return plot_backend.xlabel(labeller.make_label_vert(var_name, sel, isel), target, **kwargs)
@@ -90,6 +91,7 @@ def remove_axis(da, target, backend, **kwargs):
     """Dispatch to ``remove_axis`` function in backend."""
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
     plot_backend.remove_axis(target, **kwargs)
+
 
 def remove_ticks(da, target, backend, **kwargs):
     """Dispatch to ``remove_axis`` function in backend."""


### PR DESCRIPTION
This is my attempt to reproduce the legacy plot_trace. 

![output_00](https://github.com/arviz-devs/arviz-plots/assets/1338958/01c0b0a5-c134-4bbb-9aca-cd8494faecc7)


we have ecdf too!

![output_01](https://github.com/arviz-devs/arviz-plots/assets/1338958/fd979b9a-add0-4184-bc58-251126094898)
 

And also a lot of mistakes. 

* I added the function `scale_fig_size` (needs more works). Is this the approach we are going to use for the new ArviZ?
* I use matplotlib keywords to get/set default values, which will fail for bokeh or other backends.
* compact=true is not doing the right thing (I guess school is stacked ), see below:

![output_03](https://github.com/arviz-devs/arviz-plots/assets/1338958/5a7c60b1-344b-428b-8df3-2cfe8f0f0104)

* I added some logic to set the size of ticks, remove ticks and add x/y labels I am not sure I am doing the right thing, in particular for setting the size of ticks and remove ticks.

* I did not add any code for bokeh...

* Docstring and even variable names may need to be cleaned...

* Should we call this plot_trace_dist instead of plot_dens?

* To reduce redundancy and make the plots more compact, we may want to have a title per row with the variable names and spanning both columns.  Not sure how easy is that

<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--27.org.readthedocs.build/en/27/

<!-- readthedocs-preview arviz-plots end -->