### PR TITLE
Fixes and improvements to plot_trace_dist

### DIFF
--- a/docs/source/api/backend/interface.template.rst
+++ b/docs/source/api/backend/interface.template.rst
@@ -28,7 +28,7 @@ Plot appeareance
    xlabel
    xticks
    yticks
-   ticks_size
+   ticklabel_props
    remove_ticks
    remove_axis
 

--- a/docs/source/api/visuals.rst
+++ b/docs/source/api/visuals.rst
@@ -34,6 +34,6 @@ Plot customization elements
 .. autosummary::
    :toctree: generated/
 
-   ticks_size
+   ticklabel_props
    remove_axis
    remove_ticks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ disallow_untyped_defs = true
 
 [tool.pytest.ini_options]
 filterwarnings = ["error"]
+addopts = "--durations=10"
 testpaths = [
     "tests",
 ]

--- a/src/arviz_plots/backend/__init__.py
+++ b/src/arviz_plots/backend/__init__.py
@@ -52,6 +52,8 @@ def create_plotting_grid(
     number,
     rows=1,
     cols=1,
+    figsize=None,
+    figsize_units="inches",
     squeeze=True,
     sharex=False,
     sharey=False,
@@ -69,6 +71,10 @@ def create_plotting_grid(
         Number of plots required
     rows, cols : int, default 1
         Number of rows and columns.
+    figsize : (float, float), optional
+        Size of the figure in `figsize_units`.
+    figsize_units : {"inches", "dots"}, default "inches"
+        Units in which `figsize` is given.
     squeeze : bool, default True
         Delete dimensions of size 1 in the resulting array of :term:`plots`
     sharex, sharey : bool, default False
@@ -214,12 +220,12 @@ def yticks(ticks, labels, traget, **artist_kws):
     raise error
 
 
-def ticks_size(value, target):
-    """Interface to setting ticks size."""
+def ticklabel_props(target, *, axis="both", size=None, color=None, **artist_kws):
+    """Interface to setting size of tick labels."""
     raise error
 
 
-def remove_ticks(target, axis="y"):
+def remove_ticks(target, *, axis="y"):
     """Interface to removing ticks from a plot."""
     raise error
 

--- a/src/arviz_plots/backend/matplotlib/__init__.py
+++ b/src/arviz_plots/backend/matplotlib/__init__.py
@@ -19,23 +19,6 @@ from matplotlib.text import Text
 from .. import get_default_aes as get_agnostic_default_aes
 from .legend import legend
 
-__all__ = [
-    "create_plotting_grid",
-    "line",
-    "scatter",
-    "text",
-    "title",
-    "ylabel",
-    "xlabel",
-    "xticks",
-    "yticks",
-    "ticks_size",
-    "remove_ticks",
-    "remove_axis",
-    "legend",
-    "xlim",
-]
-
 
 class UnsetDefault:
     """Specific class to indicate an aesthetic hasn't been set."""
@@ -81,6 +64,8 @@ def create_plotting_grid(
     number,
     rows=1,
     cols=1,
+    figsize=None,
+    figsize_units="inches",
     squeeze=True,
     sharex=False,
     sharey=False,
@@ -96,8 +81,12 @@ def create_plotting_grid(
     ----------
     number : int
         Number of axes required
-    rows, cols : int
+    rows, cols : int, default 1
         Number of rows and columns.
+    figsize : (float, float), optional
+        Size of the figure in `figsize_units`.
+    figsize_units : {"inches", "dots"}, default "inches"
+        Units in which `figsize` is given.
     squeeze : bool, default True
     sharex, sharey : bool, default False
     polar : bool
@@ -119,6 +108,13 @@ def create_plotting_grid(
     if plot_hspace is not None:
         kwargs["gridspec_kw"] = kwargs.get("gridspec_kw", {}).copy()
         kwargs["gridspec_kw"].setdefault("wspace", plot_hspace)
+
+    if figsize is not None:
+        if figsize_units == "dots":
+            dpi = rcParams["figure.dpi"]
+            figsize = (figsize[0] / dpi, figsize[1] / dpi)
+        elif figsize_units != "inches":
+            raise ValueError(f"figsize_units must be 'dots' or 'inches', but got {figsize_units}")
     fig, axes = subplots(
         rows,
         cols,
@@ -259,12 +255,13 @@ def xlim(lims, target, **artist_kws):
     target.set_xlim(lims, **artist_kws)
 
 
-def ticks_size(value, target):
+def ticklabel_props(target, *, axis="both", size=unset, color=unset, **artist_kws):
     """Interface to matplotlib for setting ticks size."""
-    target.tick_params(axis="both", labelsize=value)
+    kwargs = {"labelsize": size, "labelcolor": color}
+    target.tick_params(axis=axis, **_filter_kwargs(kwargs, None, artist_kws))
 
 
-def remove_ticks(target, axis="y"):
+def remove_ticks(target, *, axis="y"):
     """Interface to matplotlib for removing ticks from a plot."""
     if axis == "y":
         target.yaxis.set_ticks([])

--- a/src/arviz_plots/plots/distplot.py
+++ b/src/arviz_plots/plots/distplot.py
@@ -108,7 +108,7 @@ def plot_dist(
     stats_kwargs : mapping, optional
         Valid keys are:
 
-        * density -> passed to kde
+        * density -> passed to kde, ecdf, ...
         * credible_interval -> passed to eti or hdi
         * point_estimate -> passed to mean, median or mode
 

--- a/src/arviz_plots/plots/traceplot.py
+++ b/src/arviz_plots/plots/traceplot.py
@@ -47,8 +47,9 @@ def plot_trace(
     plot_kwargs : mapping, optional
         Valid keys are:
 
-        * trace -> passed to visuals.line
-        * divergence -> passed to visuals.line_x
+        * trace -> passed to :func:`~.visuals.line`
+        * divergence -> passed to :func:`~.visuals.trace_rug`
+        * title -> :func:`~.visuals.labelled_title`
 
     pc_kwargs : mapping
         Passed to :class:`arviz_plots.PlotCollection`
@@ -56,6 +57,20 @@ def plot_trace(
     Returns
     -------
     PlotCollection
+
+    Examples
+    --------
+    Default plot_trace
+
+    .. plot::
+        :context: close-figs
+
+        >>> from arviz_plots import plot_trace, style
+        >>> style.use("arviz-clean")
+        >>> from arviz_base import load_arviz_data
+        >>> centered = load_arviz_data('centered_eight')
+        >>> plot_trace(centered)
+
     """
     if sample_dims is None:
         sample_dims = rcParams["data.sample_dims"]

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -32,23 +32,32 @@ def line_x(da, target, backend, y=None, **kwargs):
     return plot_backend.line(da, y, target, **kwargs)
 
 
-def line(da, target, backend, coord=None, **kwargs):
+def line(da, target, backend, xname=None, **kwargs):
     """Plot a line along the y axis with x being the range of len(y)."""
     if len(da.shape) != 1:
         raise ValueError(f"Expected unidimensional data but got {da.sizes}")
     yvalues = da.values
-    xvalues = np.arange(len(yvalues)) if coord is None else da.coords[coord]
+    xvalues = np.arange(len(yvalues)) if xname is None else da[xname]
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
     return plot_backend.line(xvalues, yvalues, target, **kwargs)
 
 
-def trace_rug(da, target, backend, mask, coord=None, y=None, **kwargs):
+def trace_rug(da, target, backend, mask, xname=None, y=None, **kwargs):
     """Create a rug plot with the subset of `da` indicated by `mask`."""
-    if len(da.shape) != 1:
-        raise ValueError(f"Expected unidimensional data but got {da.sizes}")
-    xvalues = np.arange(len(da)) if coord is None else da.coords[coord]
-    if y is None:
-        y = da.min().item()
+    xname = xname.item() if hasattr(xname, "item") else xname
+    if xname is False:
+        xvalues = da
+    else:
+        if xname is None:
+            if len(da.shape) != 1:
+                raise ValueError(f"Expected unidimensional data but got {da.sizes}")
+            xvalues = np.arange(len(da))
+        else:
+            xvalues = da[xname]
+        if y is None:
+            y = da.min().item()
+    if len(xvalues.shape) != 1:
+        raise ValueError(f"Expected unidimensional data but got {xvalues.sizes}")
     return scatter_x(xvalues[mask], target=target, backend=backend, y=y, **kwargs)
 
 
@@ -153,22 +162,38 @@ def labelled_title(da, target, backend, *, labeller, var_name, sel, isel, **kwar
     return plot_backend.title(labeller.make_label_vert(var_name, sel, isel), target, **kwargs)
 
 
-def labelled_y(da, target, backend, *, labeller, var_name, sel, isel, **kwargs):
+def labelled_y(
+    da, target, backend, *, text=None, labeller=None, var_name=None, sel=None, isel=None, **kwargs
+):
     """Add a y label to a plot using an ArviZ labeller."""
+    if text is None and labeller is None:
+        raise ValueError("Either text or labeller must be provided")
+    if text is not None and labeller is not None:
+        raise ValueError("Only text or labeller can be provided")
+    if labeller is not None:
+        text = labeller.make_label_vert(var_name, sel, isel)
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
-    return plot_backend.ylabel(labeller.make_label_vert(var_name, sel, isel), target, **kwargs)
+    return plot_backend.ylabel(text, target, **kwargs)
 
 
-def labelled_x(da, target, backend, *, labeller, var_name, sel, isel, **kwargs):
+def labelled_x(
+    da, target, backend, *, text=None, labeller=None, var_name=None, sel=None, isel=None, **kwargs
+):
     """Add a x label to a plot using an ArviZ labeller."""
+    if text is None and labeller is None:
+        raise ValueError("Either text or labeller must be provided")
+    if text is not None and labeller is not None:
+        raise ValueError("Only text or labeller can be provided")
+    if labeller is not None:
+        text = labeller.make_label_vert(var_name, sel, isel)
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
-    return plot_backend.xlabel(labeller.make_label_vert(var_name, sel, isel), target, **kwargs)
+    return plot_backend.xlabel(text, target, **kwargs)
 
 
-def ticks_size(da, target, backend, *, value, **kwargs):
+def ticklabel_props(da, target, backend, **kwargs):
     """Set the size of ticks."""
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
-    return plot_backend.ticks_size(value, target)
+    return plot_backend.ticklabel_props(target, **kwargs)
 
 
 def remove_axis(da, target, backend, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,69 @@
+# pylint: disable=redefined-outer-name
+"""Configuration for test suite."""
+import logging
+import os
+
+import pytest
+
+_log = logging.getLogger("arviz_plots")
+
+
+def pytest_addoption(parser):
+    """Definition for command line option to save figures from tests."""
+    parser.addoption("--save", nargs="?", const="test_images", help="Save images rendered by plot")
+    parser.addoption("--skip-mpl", action="store_const", const=True, help="Skip matplotlib tests")
+    parser.addoption("--skip-bokeh", action="store_const", const=True, help="Skip bokeh tests")
+
+
+@pytest.fixture(scope="session")
+def save_figs(request):
+    """Enable command line switch for saving generation figures upon testing."""
+    fig_dir = request.config.getoption("--save")
+
+    if fig_dir is not None:
+        # Try creating directory if it doesn't exist
+        _log.info("Saving generated images in %s", fig_dir)
+
+        os.makedirs(fig_dir, exist_ok=True)
+        _log.info("Directory %s created", fig_dir)
+
+        # Clear all files from the directory
+        # Does not alter or delete directories
+        for file in os.listdir(fig_dir):
+            full_path = os.path.join(fig_dir, file)
+
+            try:
+                os.remove(full_path)
+
+            except OSError:
+                _log.info("Failed to remove %s", full_path)
+
+    return fig_dir
+
+
+@pytest.fixture(scope="function")
+def clean_plots(request, save_figs):
+    """Close plots after each test, saving too if --save is specified during test invocation."""
+
+    def fin():
+        if "backend" in request.fixturenames and "matplotlib" in request.keywords:
+            import matplotlib.pyplot as plt
+
+            if save_figs is not None:
+                plt.savefig(f"{os.path.join(save_figs, request.node.name)}.png")
+            plt.close("all")
+
+    request.addfinalizer(fin)
+
+
+@pytest.fixture(scope="function")
+def check_skips(request):
+    """Skip bokeh or matplotlib tests if requested via command line."""
+    skip_mpl = request.config.getoption("--skip-mpl")
+    skip_bokeh = request.config.getoption("--skip-bokeh")
+
+    if "backend" in request.fixturenames:
+        if skip_mpl and "matplotlib" in request.keywords:
+            pytest.skip(reason="Requested skipping matplolib tests via command line argument")
+        if skip_bokeh and "bokeh" in request.keywords:
+            pytest.skip(reason="Requested skipping bokeh tests via command line argument")

--- a/tests/test_plot_collection.py
+++ b/tests/test_plot_collection.py
@@ -25,6 +25,8 @@ def dataset(seed=31):
 
 
 @pytest.mark.parametrize("backend", ["matplotlib", "bokeh"])
+@pytest.mark.usefixtures("clean_plots")
+@pytest.mark.usefixtures("check_skips")
 class TestFacetting:
     def test_wrap(self, dataset, backend):
         pc = PlotCollection.wrap(


### PR DESCRIPTION
closes #28 and closes #29.

Makes plot_trace_dist work with bokeh and with all combinations of compact and combined (also testing all 4 cases).
In addition it ensures it supports sample_dims="sample" (changes also done for plot_trace).

It still needs more work on docs and rebasing on top of #35 to make it work with the neutral element concept, which could be challenging for combined=True

<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--36.org.readthedocs.build/en/36/

<!-- readthedocs-preview arviz-plots end -->