### PR TITLE
Add ESS Plot

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -474,7 +474,7 @@ max-locals=15
 max-parents=7
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods=25
+max-public-methods=20
 
 # Maximum number of return / yield for function / method body
 max-returns=6

--- a/.pylintrc
+++ b/.pylintrc
@@ -474,7 +474,7 @@ max-locals=15
 max-parents=7
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods=20
+max-public-methods=25
 
 # Maximum number of return / yield for function / method body
 max-returns=6

--- a/.pylintrc
+++ b/.pylintrc
@@ -67,6 +67,7 @@ disable=missing-docstring,
         no-member,
         import-error,
         possibly-used-before-assignment,
+        too-many-positional-arguments,
         fixme
 
 

--- a/docs/source/api/plots.rst
+++ b/docs/source/api/plots.rst
@@ -23,3 +23,4 @@ A complementary introduction and guide to ``plot_...`` functions is available at
    plot_ridge
    plot_trace
    plot_trace_dist
+   plot_ess

--- a/docs/source/api/plots.rst
+++ b/docs/source/api/plots.rst
@@ -19,8 +19,8 @@ A complementary introduction and guide to ``plot_...`` functions is available at
 
    plot_compare
    plot_dist
+   plot_ess
    plot_forest
    plot_ridge
    plot_trace
    plot_trace_dist
-   plot_ess

--- a/docs/source/api/visuals.rst
+++ b/docs/source/api/visuals.rst
@@ -24,6 +24,7 @@ Data and axis annotating elements
    :toctree: generated/
 
    annotate_label
+   annotate_xy
    point_estimate_text
    labelled_title
    labelled_y

--- a/docs/source/api/visuals.rst
+++ b/docs/source/api/visuals.rst
@@ -13,6 +13,7 @@ Data plotting elements
    line
    line_xy
    line_x
+   scatter_xy
    scatter_x
    ecdf_line
    hist

--- a/docs/source/gallery/inference_diagnostics/plot_ess_local.py
+++ b/docs/source/gallery/inference_diagnostics/plot_ess_local.py
@@ -1,0 +1,25 @@
+"""
+# ESS Local plot
+
+Facetted local ESS plot
+
+---
+
+:::{seealso}
+API Documentation: {func}`~arviz_plots.plot_ess`
+:::
+"""
+
+from arviz_base import load_arviz_data
+
+import arviz_plots as azp
+
+azp.style.use("arviz-clean")
+
+data = load_arviz_data("centered_eight")
+pc = azp.plot_ess(
+    data,
+    kind="local",
+    backend="none",  # change to preferred backend
+)
+pc.show()

--- a/docs/source/gallery/inference_diagnostics/plot_ess_local.py
+++ b/docs/source/gallery/inference_diagnostics/plot_ess_local.py
@@ -21,5 +21,6 @@ pc = azp.plot_ess(
     data,
     kind="local",
     backend="none",  # change to preferred backend
+    rug=True,
 )
 pc.show()

--- a/docs/source/gallery/inference_diagnostics/plot_ess_models.py
+++ b/docs/source/gallery/inference_diagnostics/plot_ess_models.py
@@ -1,0 +1,25 @@
+"""
+# ESS comparison plot
+
+Full ESS (Either local or quantile) comparison between different models
+
+---
+
+:::{seealso}
+API Documentation: {func}`~arviz_plots.plot_ess`
+:::
+"""
+
+from arviz_base import load_arviz_data
+
+import arviz_plots as azp
+
+azp.style.use("arviz-clean")
+
+c = load_arviz_data("centered_eight")
+n = load_arviz_data("non_centered_eight")
+pc = azp.plot_ess(
+    {"Centered": c, "Non Centered": n},
+    backend="none",  # change to preferred backend
+)
+pc.show()

--- a/docs/source/gallery/inference_diagnostics/plot_ess_quantile.py
+++ b/docs/source/gallery/inference_diagnostics/plot_ess_quantile.py
@@ -1,0 +1,25 @@
+"""
+# ESS Quantile plot
+
+Facetted quantile ESS plot
+
+---
+
+:::{seealso}
+API Documentation: {func}`~arviz_plots.plot_ess`
+:::
+"""
+
+from arviz_base import load_arviz_data
+
+import arviz_plots as azp
+
+azp.style.use("arviz-clean")
+
+data = load_arviz_data("centered_eight")
+pc = azp.plot_ess(
+    data,
+    kind="quantile",
+    backend="none",  # change to preferred backend
+)
+pc.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dynamic = ["version", "description"]
 dependencies = [
   "arviz-base==0.2",
-  "arviz-stats[xarray] @ git+https://github.com/arviz-devs/arviz-stats",
+  "arviz-stats[xarray] @ git+https://github.com/arviz-devs/arviz-stats@1d_ess",
 ]
 
 [tool.flit.module]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dynamic = ["version", "description"]
 dependencies = [
   "arviz-base==0.2",
-  "arviz-stats[xarray] @ git+https://github.com/arviz-devs/arviz-stats@rankdata",
+  "arviz-stats[xarray] @ git+https://github.com/arviz-devs/arviz-stats",
 ]
 
 [tool.flit.module]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dynamic = ["version", "description"]
 dependencies = [
   "arviz-base==0.2",
-  "arviz-stats[xarray]==0.2",
+  "arviz-stats[xarray] @ git+https://github.com/arviz-devs/arviz-stats@rankdata",
 ]
 
 [tool.flit.module]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dynamic = ["version", "description"]
 dependencies = [
   "arviz-base==0.2",
-  "arviz-stats[xarray] @ git+https://github.com/arviz-devs/arviz-stats@1d_ess",
+  "arviz-stats[xarray] @ git+https://github.com/arviz-devs/arviz-stats",
 ]
 
 [tool.flit.module]

--- a/src/arviz_plots/plots/__init__.py
+++ b/src/arviz_plots/plots/__init__.py
@@ -2,6 +2,7 @@
 
 from .compareplot import plot_compare
 from .distplot import plot_dist
+from .essplot import plot_ess
 from .forestplot import plot_forest
 from .ridgeplot import plot_ridge
 from .tracedistplot import plot_trace_dist
@@ -13,5 +14,6 @@ __all__ = [
     "plot_forest",
     "plot_trace",
     "plot_trace_dist",
+    "plot_ess",
     "plot_ridge",
 ]

--- a/src/arviz_plots/plots/essplot.py
+++ b/src/arviz_plots/plots/essplot.py
@@ -1,0 +1,251 @@
+"""ess plot code."""
+
+# imports
+# import warnings
+from copy import copy
+
+import arviz_stats  # pylint: disable=unused-import
+import numpy as np
+import xarray as xr
+from arviz_base import rcParams
+from arviz_base.labels import BaseLabeller
+
+from arviz_plots.plot_collection import PlotCollection
+from arviz_plots.plots.utils import filter_aes, process_group_variables_coords
+from arviz_plots.visuals import labelled_title, scatter_xy
+
+
+# function signature
+def plot_ess(
+    # initial base arguments
+    dt,
+    var_names=None,
+    filter_vars=None,
+    group="posterior",
+    coords=None,
+    sample_dims=None,
+    # plot specific arguments
+    kind="local",
+    relative=False,
+    # rug=False,
+    # rug_kind="diverging",
+    n_points=20,
+    # extra_methods=False,
+    # min_ess=400,
+    # more base arguments
+    plot_collection=None,
+    backend=None,
+    labeller=None,
+    aes_map=None,
+    plot_kwargs=None,
+    stats_kwargs=None,
+    pc_kwargs=None,
+):
+    """Plot effective sample size plots.
+
+    Parameters
+    ----------
+    dt : DataTree or dict of {str : DataTree}
+        Input data. In case of dictionary input, the keys are taken to be model names.
+        In such cases, a dimension "model" is generated and can be used to map to aesthetics.
+    var_names : str or sequence of str, optional
+        One or more variables to be plotted.
+        Prefix the variables by ~ when you want to exclude them from the plot.
+    filter_vars : {None, “like”, “regex”}, default None
+        If None, interpret `var_names` as the real variables names.
+        If “like”, interpret `var_names` as substrings of the real variables names.
+        If “regex”, interpret `var_names` as regular expressions on the real variables names.
+    group : str, default "posterior"
+        Group to be plotted.
+    coords : dict, optional
+    sample_dims : str or sequence of hashable, optional
+        Dimensions to reduce unless mapped to an aesthetic.
+        Defaults to ``rcParams["data.sample_dims"]``
+    kind : {"local", "quantile", "evolution"}, default "local"
+        Specify the kind of plot:
+
+        * The ``kind="local"`` argument generates the ESS' local efficiency for
+          estimating quantiles of a desired posterior.
+        * The ``kind="quantile"`` argument generates the ESS' local efficiency
+          for estimating small-interval probability of a desired posterior.
+        * The ``kind="evolution"`` argument generates the estimated ESS'
+          with incrised number of iterations of a desired posterior.
+        WIP: add the other kinds for each kind of ess computation in arviz stats
+
+    relative : bool, default False
+        Show relative ess in plot ``ress = ess / N``.
+    rug : bool, default False
+        Add a `rug plot <https://en.wikipedia.org/wiki/Rug_plot>`_ for a specific subset of values.
+    rug_kind : str, default "diverging"
+        Variable in sample stats to use as rug mask. Must be a boolean variable.
+    n_points : int, default 20
+        Number of points for which to plot their quantile/local ess or number of subsets
+        in the evolution plot.
+    extra_methods : bool, default False
+        Plot mean and sd ESS as horizontal lines. Not taken into account if ``kind = 'evolution'``.
+    min_ess : int, default 400
+        Minimum number of ESS desired. If ``relative=True`` the line is plotted at
+        ``min_ess / n_samples`` for local and quantile kinds and as a curve following
+        the ``min_ess / n`` dependency in evolution kind.
+    plot_collection : PlotCollection, optional
+    backend : {"matplotlib", "bokeh"}, optional
+    labeller : labeller, optional
+    aes_map : mapping of {str : sequence of str or False}, optional
+        Mapping of artists to aesthetics that should use their mapping in `plot_collection`
+        when plotted. Valid keys are the same as for `plot_kwargs`.
+
+    plot_kwargs : mapping of {str : mapping or False}, optional
+        Valid keys are:
+
+        * One of "local", "quantile", "evolution", matching the `kind` argument.
+            * "local" -> passed to :func:`~arviz_plots.visuals.scatter_xy`
+            * "quantile" -> passed to :func:`~arviz_plots.visuals.line_xy`
+            * "evolution" -> passed to :func:`~arviz_plots.visuals.line_xy`
+
+        * divergence -> passed to :func:`~.visuals.trace_rug`
+        * title -> passed to :func:`~arviz_plots.visuals.labelled_title`
+
+    stats_kwargs : mapping, optional
+        Valid keys are:
+
+        * ess -> passed to ess
+
+    pc_kwargs : mapping
+        Passed to :class:`arviz_plots.PlotCollection.wrap`
+
+    Returns
+    -------
+    PlotCollection
+    """
+    # initial defaults
+    if sample_dims is None:
+        sample_dims = rcParams["data.sample_dims"]
+    if isinstance(sample_dims, str):
+        sample_dims = [sample_dims]
+
+    # mutable inputs
+    if plot_kwargs is None:
+        plot_kwargs = {}
+    if pc_kwargs is None:
+        pc_kwargs = {}
+    else:
+        pc_kwargs = pc_kwargs.copy()
+
+    if stats_kwargs is None:
+        stats_kwargs = {}
+
+    # processing dt/group/coords/filtering
+    distribution = process_group_variables_coords(
+        dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords
+    )
+
+    # set plot collection initialization defaults if it doesnt exist
+    if plot_collection is None:
+        if backend is None:
+            backend = rcParams["plot.backend"]
+        pc_kwargs.setdefault("col_wrap", 5)
+        pc_kwargs.setdefault(
+            "cols",
+            ["__variable__"]
+            + [dim for dim in distribution.dims if dim not in {"model"}.union(sample_dims)],
+        )
+        if "model" in distribution:
+            pc_kwargs["aes"] = pc_kwargs.get("aes", {}).copy()
+            pc_kwargs["aes"].setdefault("color", ["model"])
+        plot_collection = PlotCollection.wrap(
+            distribution,
+            backend=backend,
+            **pc_kwargs,
+        )
+
+    # set plot collection dependent defaults (like aesthetics mappings for each artist)
+    if aes_map is None:
+        aes_map = {}
+    else:
+        aes_map = aes_map.copy()
+    aes_map.setdefault(kind, plot_collection.aes_set)
+    if labeller is None:
+        labeller = BaseLabeller()
+
+    # compute and add ess subplots
+    # step 1
+    ess_kwargs = copy(plot_kwargs.get(kind, {}))
+
+    if ess_kwargs is not False:
+        # step 2
+        ess_dims, _, ess_ignore = filter_aes(plot_collection, aes_map, kind, sample_dims)
+        if kind == "local":
+            probs = np.linspace(0, 1, n_points, endpoint=False)
+            xdata = probs
+
+            # step 3
+            ess_y_dataset = xr.concat(
+                [
+                    distribution.azstats.ess(
+                        dims=ess_dims,
+                        method="local",
+                        relative=relative,
+                        prob=[p, (p + 1 / n_points)],
+                        **stats_kwargs.get("ess", {}),
+                    )
+                    for p in probs
+                ],
+                dim="ess_dim",
+            )
+            print(f"\n ess_y_dataset = {ess_y_dataset}")
+
+            # broadcasting xdata to match ess_y_dataset's shape
+            xdata_da = xr.DataArray(xdata, dims="ess_dim")
+            print(f"\n xdata_da ={xdata_da}")
+
+            # broadcasting xdata_da to match shape of each variable in ess_y_dataset
+            xdata_broadcasted_dict = {}
+            for var in ess_y_dataset.data_vars:
+                _, xdata_broadcasted = xr.broadcast(ess_y_dataset[var], xdata_da)
+                xdata_broadcasted_dict[var] = xdata_broadcasted
+
+            # creating a new dataset from dict of broadcasted xdata
+            xdata_dataset = xr.Dataset(xdata_broadcasted_dict)
+            print(f"\n xdata_dataset = {xdata_dataset}")
+
+            # concatenating xdata_dataset and ess_y_dataset along plot_axis
+            ess_dataset = xr.concat([xdata_dataset, ess_y_dataset], dim="plot_axis")
+
+            # assigning 'x' and 'y' coordinates to the 'plot_axis' dimension
+            ess_dataset["plot_axis"] = ["x", "y"]
+            print(f"\n ess_dataset = {ess_dataset}")
+
+            # step 4
+            # if "color" not in ess_aes:
+            #    ess_kwargs.setdefault("color", "gray")
+
+            # step 5
+            plot_collection.map(
+                scatter_xy, "local", data=ess_dataset, ignore_aes=ess_ignore, **ess_kwargs
+            )
+
+        # WIP: repeat previous pattern for all ess methods as kind='method'
+
+        # all the ess methods supported in arviz stats:
+        # valid_methods = {
+        #        "bulk", "tail", "mean", "sd", "quantile", "local", "median", "mad",
+        #        "z_scale", "folded", "identity"
+        #    }
+
+    # plot titles for each facetted subplot
+    title_kwargs = copy(plot_kwargs.get("title", {}))
+
+    if title_kwargs is not False:
+        _, title_aes, title_ignore = filter_aes(plot_collection, aes_map, "title", sample_dims)
+        if "color" not in title_aes:
+            title_kwargs.setdefault("color", "black")
+        plot_collection.map(
+            labelled_title,
+            "title",
+            ignore_aes=title_ignore,
+            subset_info=True,
+            labeller=labeller,
+            **title_kwargs,
+        )
+
+    return plot_collection

--- a/src/arviz_plots/plots/essplot.py
+++ b/src/arviz_plots/plots/essplot.py
@@ -121,13 +121,20 @@ def plot_ess(
     -------
     PlotCollection
 
+    Notes
+    -----
+    Depending on the number of models, a slight x-axis separation aesthetic is applied for each
+    ess point for distinguishability in case of overlap
+
+    See Also
+    --------
+    :ref:`plots_intro` :
+        General introduction to batteries-included plotting functions, common use and logic overview
+
     Examples
     --------
-    The following examples focus on behaviour specific to ``plot_ess``.
-    For a general introduction to batteries-included functions like this one and common
-    usage examples see :ref:`plots_intro`
-
-    Default plot_ess for a single model:
+    We can manually map the color to the variable, and have the mapping apply
+    to the title too instead of only the ess markers:
 
     .. plot::
         :context: close-figs
@@ -135,29 +142,7 @@ def plot_ess(
         >>> from arviz_plots import plot_ess, style
         >>> style.use("arviz-clean")
         >>> from arviz_base import load_arviz_data
-        >>> centered = load_arviz_data('centered_eight')
         >>> non_centered = load_arviz_data('non_centered_eight')
-        >>> pc = plot_ess(centered)
-
-    Default plot_ess for multiple models: (Depending on the number of models, a slight
-    x-axis separation aesthetic is applied for each ess point for distinguishability in
-    case of overlap)
-
-    .. plot::
-        :context: close-figs
-
-        >>> pc = plot_ess(
-        >>>     {"centered": centered, "non centered": non_centered},
-        >>>     coords={"school": ["Choate", "Deerfield", "Hotchkiss"]},
-        >>> )
-        >>> pc.add_legend("model")
-
-    We can also manually map the color to the variable, and have the mapping apply
-    to the title too instead of only the ess markers:
-
-    .. plot::
-        :context: close-figs
-
         >>> pc = plot_ess(
         >>>     non_centered,
         >>>     coords={"school": ["Choate", "Deerfield", "Hotchkiss"]},
@@ -165,31 +150,53 @@ def plot_ess(
         >>>     aes_map={"title": ["color"]},
         >>> )
 
-    If we add a mapping (like color) manually to the variable, but not specify which artist
-    to apply the mapping to- then it is applied to the 'ess' marker artist by default:
+    We can add extra methods to plot the mean and standard deviation as lines, and adjust
+    the minimum ess baseline as well:
 
     .. plot::
         :context: close-figs
 
         >>> pc = plot_ess(
-        >>>     centered,
+        >>>     non_centered,
         >>>     coords={"school": ["Choate", "Deerfield", "Hotchkiss"]},
-        >>>     pc_kwargs={"aes": {"color": ["__variable__"]}},
+        >>>     extra_methods=True,
+        >>>     min_ess=200,
         >>> )
 
-    The artists' visual features can also be customized through plot_kwargs, based on the
-    kwargs that the visual element function for the artist accepts- like all the other
-    batteries included plots. For example, for the 'ess' artist, the scatter_xy function is
-    used. So if we want to change the marker:
+    Rugs can also be added:
 
     .. plot::
         :context: close-figs
 
         >>> pc = plot_ess(
-        >>>    centered,
-        >>>    coords={"school": ["Choate", "Deerfield", "Hotchkiss"]},
-        >>>    plot_kwargs={"ess": {"marker": "_"}},
+        >>>     non_centered,
+        >>>     coords={"school": ["Choate", "Deerfield", "Hotchkiss"]},
+        >>>     rug=True,
         >>> )
+
+    Relative ESS can be plotted instead of absolute:
+
+    .. plot::
+        :context: close-figs
+
+        >>> pc = plot_ess(
+        >>>     non_centered,
+        >>>     coords={"school": ["Choate", "Deerfield", "Hotchkiss"]},
+        >>>     relative=True,
+        >>> )
+
+    We can also adjust the number of points:
+
+    .. plot::
+        :context: close-figs
+
+        >>> pc = plot_ess(
+        >>>     non_centered,
+        >>>     coords={"school": ["Choate", "Deerfield", "Hotchkiss"]},
+        >>>     n_points=10,
+        >>> )
+
+    .. minigallery:: plot_ess
 
     """
     # initial defaults

--- a/src/arviz_plots/plots/essplot.py
+++ b/src/arviz_plots/plots/essplot.py
@@ -202,17 +202,6 @@ def plot_ess(
 
     ylabel = "{}"
 
-    # from importlib.metadata import version, PackageNotFoundError
-
-    # get the version of the arviz_stats module
-    # try:
-    #    arviz_stats_version = version("arviz_stats")
-    #    print(f"arviz_stats version: {arviz_stats_version}")
-    # except PackageNotFoundError:
-    #    print("arviz_stats package is not installed")
-
-    # print(f"arviz_stats version: {arviz_stats.__version__}")
-
     # mutable inputs
     if plot_kwargs is None:
         plot_kwargs = {}
@@ -347,7 +336,6 @@ def plot_ess(
             div_reduce_dims = [dim for dim in distribution.dims if dim not in aux_dim_list]
 
             values = distribution.azstats.compute_ranks(relative=True)
-            print(f"\n compute_ranks values = {values}")
 
             plot_collection.map(
                 trace_rug,
@@ -372,18 +360,20 @@ def plot_ess(
 
     # plot mean and sd and annotate them
     if extra_methods is not False:
-        mean_ess = None
-        sd_ess = None
+        # computing mean_ess
+        mean_dims, mean_aes, mean_ignore = filter_aes(plot_collection, aes_map, "mean", sample_dims)
+        mean_ess = distribution.azstats.ess(
+            dims=mean_dims, method="mean", relative=relative, **stats_kwargs.get("mean", {})
+        )
+
+        # computing sd_ess
+        sd_dims, sd_aes, sd_ignore = filter_aes(plot_collection, aes_map, "sd", sample_dims)
+        sd_ess = distribution.azstats.ess(
+            dims=sd_dims, method="sd", relative=relative, **stats_kwargs.get("sd", {})
+        )
 
         mean_kwargs = copy(plot_kwargs.get("mean", {}))
         if mean_kwargs is not False:
-            mean_dims, mean_aes, mean_ignore = filter_aes(
-                plot_collection, aes_map, "mean", sample_dims
-            )
-            mean_ess = distribution.azstats.ess(
-                dims=mean_dims, method="mean", relative=relative, **stats_kwargs.get("mean", {})
-            )
-
             # getting 2nd default linestyle for chosen backend and assigning it by default
             mean_kwargs.setdefault("linestyle", linestyles[1])
 
@@ -401,11 +391,6 @@ def plot_ess(
 
         sd_kwargs = copy(plot_kwargs.get("sd", {}))
         if sd_kwargs is not False:
-            sd_dims, sd_aes, sd_ignore = filter_aes(plot_collection, aes_map, "sd", sample_dims)
-            sd_ess = distribution.azstats.ess(
-                dims=sd_dims, method="sd", relative=relative, **stats_kwargs.get("sd", {})
-            )
-
             sd_kwargs.setdefault("linestyle", linestyles[2])
 
             if "color" not in sd_aes:
@@ -434,9 +419,6 @@ def plot_ess(
 
             mean_text_kwargs.setdefault("x", 1)
             mean_text_kwargs.setdefault("horizontal_align", "right")
-            # mean_text_kwargs.setdefault(
-            #    "vertical_align", "bottom"
-            # )  # by default set to bottom for mean
 
             # pass the mean vertical_align data for vertical alignment setting
             if mean_va_align is not None:
@@ -467,7 +449,6 @@ def plot_ess(
 
             sd_text_kwargs.setdefault("x", 1)
             sd_text_kwargs.setdefault("horizontal_align", "right")
-            # sd_text_kwargs.setdefault("vertical_align", "top")  # by default set to top for sd
 
             # pass the sd vertical_align data for vertical alignment setting
             if sd_va_align is not None:
@@ -543,7 +524,6 @@ def plot_ess(
             "xlabel",
             ignore_aes=labels_ignore,
             subset_info=True,
-            store_artist=False,
             **xlabel_kwargs,
         )
 
@@ -564,12 +544,7 @@ def plot_ess(
             "ylabel",
             ignore_aes=labels_ignore,
             subset_info=True,
-            store_artist=False,
             **ylabel_kwargs,
         )
-
-    # print(f"\n plot_collection.viz = {plot_collection.viz}")
-
-    # print(f"\n plot_collection.aes = {plot_collection.aes}")
 
     return plot_collection

--- a/src/arviz_plots/plots/essplot.py
+++ b/src/arviz_plots/plots/essplot.py
@@ -66,7 +66,7 @@ def plot_ess(
     sample_dims : str or sequence of hashable, optional
         Dimensions to reduce unless mapped to an aesthetic.
         Defaults to ``rcParams["data.sample_dims"]``
-    kind : {"local", "quantile", "evolution"}, default "local"
+    kind : {"local", "quantile"}, default "local"
         Specify the kind of plot:
 
         * The ``kind="local"`` argument generates the ESS' local efficiency
@@ -99,10 +99,6 @@ def plot_ess(
         Valid keys are:
 
         * ess -> passed to :func:`~arviz_plots.visuals.scatter_xy`
-            if `kind`='local',
-            else passed to :func:`~arviz_plots.visuals.scatter_xy`
-            if `kind` = 'quantile'
-
         * rug -> passed to :func:`~.visuals.trace_rug`
         * title -> passed to :func:`~arviz_plots.visuals.labelled_title`
         * xlabel -> passed to :func:`~arviz_plots.visuals.labelled_x`
@@ -126,12 +122,85 @@ def plot_ess(
     Returns
     -------
     PlotCollection
+
+    Examples
+    --------
+    The following examples focus on behaviour specific to ``plot_ess``.
+    For a general introduction to batteries-included functions like this one and common
+    usage examples see :ref:`plots_intro`
+
+    Default plot_ess for a single model:
+
+    .. plot::
+        :context: close-figs
+
+        >>> from arviz_plots import plot_ess, style
+        >>> style.use("arviz-clean")
+        >>> from arviz_base import load_arviz_data
+        >>> centered = load_arviz_data('centered_eight')
+        >>> non_centered = load_arviz_data('non_centered_eight')
+        >>> pc = plot_ess(centered)
+
+    Default plot_ess for multiple models: (Depending on the number of models, a slight
+    x-axis separation aesthetic is applied for each ess point for distinguishability in
+    case of overlap)
+
+    .. plot::
+        :context: close-figs
+
+        >>> pc = plot_ess(
+        >>>     {"centered": centered, "non centered": non_centered},
+        >>>     coords={"school": ["Choate", "Deerfield", "Hotchkiss"]},
+        >>> )
+        >>> pc.add_legend("model")
+
+    We can also manually map the color to the variable, and have the mapping apply
+    to the title too instead of only the ess markers:
+
+    .. plot::
+        :context: close-figs
+
+        >>> pc = plot_ess(
+        >>>     non_centered,
+        >>>     coords={"school": ["Choate", "Deerfield", "Hotchkiss"]},
+        >>>     pc_kwargs={"aes": {"color": ["__variable__"]}},
+        >>>     aes_map={"title": ["color"]},
+        >>> )
+
+    If we add a mapping (like color) manually to the variable, but not specify which artist
+    to apply the mapping to- then it is applied to the 'ess' marker artist by default:
+
+    .. plot::
+        :context: close-figs
+
+        >>> pc = plot_ess(
+        >>>     centered,
+        >>>     coords={"school": ["Choate", "Deerfield", "Hotchkiss"]},
+        >>>     pc_kwargs={"aes": {"color": ["__variable__"]}},
+        >>> )
+
+    The artists' visual features can also be customized through plot_kwargs, based on the
+    kwargs that the visual element function for the artist accepts- like all the other
+    batteries included plots. For example, for the 'ess' artist, the scatter_xy function is
+    used. So if we want to change the marker:
+
+    .. plot::
+        :context: close-figs
+
+        >>> pc = plot_ess(
+        >>>    centered,
+        >>>    coords={"school": ["Choate", "Deerfield", "Hotchkiss"]},
+        >>>    plot_kwargs={"ess": {"marker": "_"}},
+        >>> )
+
     """
     # initial defaults
     if sample_dims is None:
         sample_dims = rcParams["data.sample_dims"]
     if isinstance(sample_dims, str):
         sample_dims = [sample_dims]
+
+    ylabel = "{}"
 
     # from importlib.metadata import version, PackageNotFoundError
 

--- a/src/arviz_plots/plots/essplot.py
+++ b/src/arviz_plots/plots/essplot.py
@@ -34,7 +34,7 @@ def plot_ess(
     rug=False,
     rug_kind="diverging",
     n_points=20,
-    extra_methods=True,  # default False
+    extra_methods=False,
     min_ess=400,
     plot_collection=None,
     backend=None,

--- a/src/arviz_plots/plots/essplot.py
+++ b/src/arviz_plots/plots/essplot.py
@@ -346,7 +346,7 @@ def plot_ess(
                 rug_kwargs.setdefault("size", 30)
             div_reduce_dims = [dim for dim in distribution.dims if dim not in aux_dim_list]
 
-            values = distribution.azstats.compute_ranks(relative=False)
+            values = distribution.azstats.compute_ranks(relative=True)
             print(f"\n compute_ranks values = {values}")
 
             plot_collection.map(
@@ -356,6 +356,7 @@ def plot_ess(
                 ignore_aes=div_ignore,
                 y=distribution.min(div_reduce_dims),
                 mask=rug_mask,
+                xname=False,
                 **rug_kwargs,
             )  # note: after plot_ppc merge, the `trace_rug` function might change
 

--- a/src/arviz_plots/plots/essplot.py
+++ b/src/arviz_plots/plots/essplot.py
@@ -258,32 +258,24 @@ def plot_ess(
         figsize = pc_kwargs.get("plot_grid_kws", {}).get("figsize", None)
         figsize_units = pc_kwargs.get("plot_grid_kws", {}).get("figsize_units", "inches")
         if figsize is None:
-            coeff = 0.2
-            if "chain" in distribution.dims:
-                coeff += 0.1
-            if "model" in distribution.dims:
-                coeff += 0.1 * distribution.sizes["model"]
             n_plots, _ = process_facet_dims(distribution, pc_kwargs["cols"])
             col_wrap = pc_kwargs["col_wrap"]
-            print(f"\n n_plots = {n_plots},\n col_wrap = {col_wrap}")
             if n_plots <= col_wrap:
                 n_rows, n_cols = 1, n_plots
             else:
                 div_mod = divmod(n_plots, col_wrap)
                 n_rows = div_mod[0] + (div_mod[1] != 0)
                 n_cols = col_wrap
-            print(f"\n n_rows = {n_rows},\n n_cols = {n_cols}")
             figsize = plot_bknd.scale_fig_size(
                 figsize,
                 rows=n_rows,
                 cols=n_cols,
                 figsize_units=figsize_units,
             )
-            print(f"\n figsize = {figsize!r}")
             figsize_units = "dots"
         pc_kwargs["plot_grid_kws"]["figsize"] = figsize
         pc_kwargs["plot_grid_kws"]["figsize_units"] = figsize_units
-        plot_collection = PlotCollection.grid(
+        plot_collection = PlotCollection.wrap(
             distribution,
             backend=backend,
             **pc_kwargs,

--- a/src/arviz_plots/plots/utils.py
+++ b/src/arviz_plots/plots/utils.py
@@ -37,7 +37,7 @@ def get_group(data, group, allow_missing=False):
     try:
         data = data[group]
     except KeyError:
-        if allow_missing:
+        if not allow_missing:
             raise
         return None
     if isinstance(data, Dataset):

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -62,7 +62,6 @@ def line(da, target, backend, xname=None, **kwargs):
 
 def trace_rug(da, target, backend, mask, xname=None, y=None, **kwargs):
     """Create a rug plot with the subset of `da` indicated by `mask`."""
-    # print(f'\n da = {da}')
     xname = xname.item() if hasattr(xname, "item") else xname
     if xname is False:
         xvalues = da
@@ -156,7 +155,6 @@ def _ensure_scalar(*args):
 def annotate_xy(da, target, backend, *, text, x=None, y=None, vertical_align=None, **kwargs):
     """Annotate a point (x, y) in a plot."""
     if vertical_align is not None:
-        # print(f"\n vertical_align.item() = {vertical_align.item()}")
         if hasattr(vertical_align, "item"):
             kwargs["vertical_align"] = vertical_align.item()
         else:

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -91,17 +91,16 @@ def scatter_x(da, target, backend, y=None, **kwargs):
     return plot_backend.scatter(da, y, target, **kwargs)
 
 
-def scatter_xy(da, target, backend, x=None, **kwargs):
+def scatter_xy(da, target, backend, x=None, y=None, **kwargs):
     """Plot a scatter plot x vs y.
 
     The input argument `da` is split into x and y using the dimension ``plot_axis``.
+    If additional x and y arguments are provided, x and y are added to the values
+    in the `da` dataset sliced along plot_axis='x' and plot_axis='y'.
     """
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
-    # note: temporary patch only before plot_ridge merge to use _process_da_x_y
-    # print(f"\n x arg = {x}")
-    x = da.sel(plot_axis="x") if x is None else da.sel(plot_axis="x") + x
-    # print(f"\n to plot x = {x}")
-    return plot_backend.scatter(x, da.sel(plot_axis="y"), target, **kwargs)
+    x, y = _process_da_x_y(da, x, y)
+    return plot_backend.scatter(x, y, target, **kwargs)
 
 
 def ecdf_line(values, target, backend, **kwargs):

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -154,6 +154,20 @@ def _ensure_scalar(*args):
     return tuple(arg.item() if hasattr(arg, "item") else arg for arg in args)
 
 
+def annotate_xy(da, target, backend, *, text, x=None, y=None, extra_da=None, **kwargs):
+    """Annotate a point (x, y) in a plot."""
+    # kwargs["vertical_align"] will depend on extra_da if passed to this function
+    if extra_da is not None:
+        if da.values > extra_da.values:
+            kwargs["vertical_align"] = "bottom"
+        if da.values < extra_da.values:
+            kwargs["vertical_align"] = "top"
+        # if equal, default/pre-set vertical_aligns are used
+    x, y = _process_da_x_y(da, x, y)
+    plot_backend = import_module(f"arviz_plots.backend.{backend}")
+    return plot_backend.text(x, y, text, target, **kwargs)
+
+
 def point_estimate_text(
     da, target, backend, *, point_estimate, x=None, y=None, point_label="x", **kwargs
 ):

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -89,6 +89,15 @@ def scatter_x(da, target, backend, y=None, **kwargs):
     return plot_backend.scatter(da, y, target, **kwargs)
 
 
+def scatter_xy(da, target, backend, **kwargs):
+    """Plot a scatter plot x vs y.
+
+    The input argument `da` is split into x and y using the dimension ``plot_axis``.
+    """
+    plot_backend = import_module(f"arviz_plots.backend.{backend}")
+    return plot_backend.scatter(da.sel(plot_axis="x"), da.sel(plot_axis="y"), target, **kwargs)
+
+
 def ecdf_line(values, target, backend, **kwargs):
     """Plot an ecdf line."""
     plot_backend = import_module(f"arviz_plots.backend.{backend}")

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -89,13 +89,17 @@ def scatter_x(da, target, backend, y=None, **kwargs):
     return plot_backend.scatter(da, y, target, **kwargs)
 
 
-def scatter_xy(da, target, backend, **kwargs):
+def scatter_xy(da, target, backend, x=None, **kwargs):
     """Plot a scatter plot x vs y.
 
     The input argument `da` is split into x and y using the dimension ``plot_axis``.
     """
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
-    return plot_backend.scatter(da.sel(plot_axis="x"), da.sel(plot_axis="y"), target, **kwargs)
+    # note: temporary patch only before plot_ridge merge to use _process_da_x_y
+    # print(f"\n x arg = {x}")
+    x = da.sel(plot_axis="x") if x is None else da.sel(plot_axis="x") + x
+    # print(f"\n to plot x = {x}")
+    return plot_backend.scatter(x, da.sel(plot_axis="y"), target, **kwargs)
 
 
 def ecdf_line(values, target, backend, **kwargs):

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -77,8 +77,6 @@ def trace_rug(da, target, backend, mask, xname=None, y=None, **kwargs):
             y = da.min().item()
     if len(xvalues.shape) != 1:
         raise ValueError(f"Expected unidimensional data but got {xvalues.sizes}")
-    # print(f"\n trace_rug call. xvalues = {xvalues}\nmask = {mask}")
-    print(f"\n trace_rug call. xvalues[mask] = {xvalues[mask]}")
     return scatter_x(xvalues[mask], target=target, backend=backend, y=y, **kwargs)
 
 

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -60,7 +60,7 @@ def line(da, target, backend, xname=None, **kwargs):
     return plot_backend.line(xvalues, yvalues, target, **kwargs)
 
 
-def trace_rug(da, target, backend, mask, xname=None, y=None, **kwargs):
+def trace_rug(da, target, backend, mask, xname=None, y=None, scale=1, **kwargs):
     """Create a rug plot with the subset of `da` indicated by `mask`."""
     xname = xname.item() if hasattr(xname, "item") else xname
     if xname is False:
@@ -76,6 +76,8 @@ def trace_rug(da, target, backend, mask, xname=None, y=None, **kwargs):
             y = da.min().item()
     if len(xvalues.shape) != 1:
         raise ValueError(f"Expected unidimensional data but got {xvalues.sizes}")
+    xvalues = xvalues / scale
+    # print(f"\n trace_rug call. xvalues = {xvalues}\nmask = {mask}")
     return scatter_x(xvalues[mask], target=target, backend=backend, y=y, **kwargs)
 
 

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -60,8 +60,9 @@ def line(da, target, backend, xname=None, **kwargs):
     return plot_backend.line(xvalues, yvalues, target, **kwargs)
 
 
-def trace_rug(da, target, backend, mask, xname=None, y=None, scale=1, **kwargs):
+def trace_rug(da, target, backend, mask, xname=None, y=None, **kwargs):
     """Create a rug plot with the subset of `da` indicated by `mask`."""
+    # print(f'\n da = {da}')
     xname = xname.item() if hasattr(xname, "item") else xname
     if xname is False:
         xvalues = da
@@ -76,8 +77,8 @@ def trace_rug(da, target, backend, mask, xname=None, y=None, scale=1, **kwargs):
             y = da.min().item()
     if len(xvalues.shape) != 1:
         raise ValueError(f"Expected unidimensional data but got {xvalues.sizes}")
-    xvalues = xvalues / scale
     # print(f"\n trace_rug call. xvalues = {xvalues}\nmask = {mask}")
+    print(f"\n trace_rug call. xvalues[mask] = {xvalues[mask]}")
     return scatter_x(xvalues[mask], target=target, backend=backend, y=y, **kwargs)
 
 
@@ -154,15 +155,11 @@ def _ensure_scalar(*args):
     return tuple(arg.item() if hasattr(arg, "item") else arg for arg in args)
 
 
-def annotate_xy(da, target, backend, *, text, x=None, y=None, extra_da=None, **kwargs):
+def annotate_xy(da, target, backend, *, text, x=None, y=None, vertical_align=None, **kwargs):
     """Annotate a point (x, y) in a plot."""
-    # kwargs["vertical_align"] will depend on extra_da if passed to this function
-    if extra_da is not None:
-        if da.values > extra_da.values:
-            kwargs["vertical_align"] = "bottom"
-        if da.values < extra_da.values:
-            kwargs["vertical_align"] = "top"
-        # if equal, default/pre-set vertical_aligns are used
+    if vertical_align is not None:
+        # print(f"\n vertical_align.item() = {vertical_align.item()}")
+        kwargs["vertical_align"] = vertical_align.item()
     x, y = _process_da_x_y(da, x, y)
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
     return plot_backend.text(x, y, text, target, **kwargs)

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -159,7 +159,10 @@ def annotate_xy(da, target, backend, *, text, x=None, y=None, vertical_align=Non
     """Annotate a point (x, y) in a plot."""
     if vertical_align is not None:
         # print(f"\n vertical_align.item() = {vertical_align.item()}")
-        kwargs["vertical_align"] = vertical_align.item()
+        if hasattr(vertical_align, "item"):
+            kwargs["vertical_align"] = vertical_align.item()
+        else:
+            kwargs["vertical_align"] = vertical_align  # if a string and not a dataarray
     x, y = _process_da_x_y(da, x, y)
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
     return plot_backend.text(x, y, text, target, **kwargs)

--- a/tests/test_hypothesis_plots.py
+++ b/tests/test_hypothesis_plots.py
@@ -37,9 +37,11 @@ def datatree(seed=31):
 
 
 kind_value = st.sampled_from(("kde", "ecdf"))
+ess_kind_value = st.sampled_from(("local", "quantile"))
 ci_kind_value = st.sampled_from(("eti", "hdi"))
 point_estimate_value = st.sampled_from(("mean", "median"))
 plot_kwargs_value = st.sampled_from(({}, False, {"color": "red"}))
+plot_kwargs_value_no_false = st.sampled_from(({}, {"color": "red"}))
 
 
 @st.composite
@@ -194,17 +196,6 @@ def test_plot_ridge(datatree, combined, plot_kwargs, labels_shade_label):
             assert all(key in child for child in pc.viz.children.values())
 
 
-ess_kind_value = st.sampled_from(("local", "quantile"))
-ess_relative = st.booleans()
-ess_rug = st.booleans()
-ess_extra_methods = st.booleans()
-
-
-@st.composite
-def ess_n_points(draw):
-    return draw(st.integers(min_value=1, max_value=50))  # should this range be changed?
-
-
 @st.composite
 def ess_min_ess(draw):
     return draw(st.integers(min_value=10, max_value=150))  # max samples = 3 x 50 = 150
@@ -215,9 +206,9 @@ def ess_min_ess(draw):
         {},
         optional={
             "ess": plot_kwargs_value,
-            "rug": st.sampled_from(({}, {"color": "red"})),
-            "xlabel": st.sampled_from(({}, {"color": "red"})),
-            "ylabel": st.sampled_from(({}, {"color": "red"})),
+            "rug": plot_kwargs_value_no_false,
+            "xlabel": plot_kwargs_value_no_false,
+            "ylabel": plot_kwargs_value_no_false,
             "mean": plot_kwargs_value,
             "mean_text": plot_kwargs_value,
             "sd": plot_kwargs_value,
@@ -228,10 +219,10 @@ def ess_min_ess(draw):
         },
     ),
     kind=ess_kind_value,
-    relative=ess_relative,
-    rug=ess_rug,
-    n_points=ess_n_points(),
-    extra_methods=ess_extra_methods,
+    relative=st.booleans(),
+    rug=st.booleans(),
+    n_points=st.integers(min_value=1, max_value=5),
+    extra_methods=st.booleans(),
     min_ess=ess_min_ess(),
 )
 def test_plot_ess(datatree, kind, relative, rug, n_points, extra_methods, min_ess, plot_kwargs):

--- a/tests/test_hypothesis_plots.py
+++ b/tests/test_hypothesis_plots.py
@@ -196,11 +196,6 @@ def test_plot_ridge(datatree, combined, plot_kwargs, labels_shade_label):
             assert all(key in child for child in pc.viz.children.values())
 
 
-@st.composite
-def ess_min_ess(draw):
-    return draw(st.integers(min_value=10, max_value=150))  # max samples = 3 x 50 = 150
-
-
 @given(
     plot_kwargs=st.fixed_dictionaries(
         {},
@@ -215,7 +210,6 @@ def ess_min_ess(draw):
             "sd_text": plot_kwargs_value,
             "min_ess": plot_kwargs_value,
             "title": plot_kwargs_value,
-            "remove_axis": st.just(False),
         },
     ),
     kind=ess_kind_value,
@@ -223,7 +217,7 @@ def ess_min_ess(draw):
     rug=st.booleans(),
     n_points=st.integers(min_value=1, max_value=5),
     extra_methods=st.booleans(),
-    min_ess=ess_min_ess(),
+    min_ess=st.integers(min_value=10, max_value=150),
 )
 def test_plot_ess(datatree, kind, relative, rug, n_points, extra_methods, min_ess, plot_kwargs):
     pc = plot_ess(
@@ -251,5 +245,5 @@ def test_plot_ess(datatree, kind, relative, rug, n_points, extra_methods, min_es
                 assert all(key not in child for child in pc.viz.children.values())
             else:
                 assert all(key in child for child in pc.viz.children.values())
-        elif key != "remove_axis":
+        else:
             assert all(key in child for child in pc.viz.children.values())

--- a/tests/test_hypothesis_plots.py
+++ b/tests/test_hypothesis_plots.py
@@ -250,6 +250,11 @@ def test_plot_ess(datatree, kind, relative, rug, n_points, extra_methods, min_es
     for key, value in plot_kwargs.items():
         if value is False:
             assert all(key not in child for child in pc.viz.children.values())
+        elif key in ["mean", "sd", "mean_text", "sd_text"]:
+            if extra_methods is False:
+                assert all(key not in child for child in pc.viz.children.values())
+            else:
+                assert all(key in child for child in pc.viz.children.values())
         elif key == "rug":
             if rug is False:
                 assert all(key not in child for child in pc.viz.children.values())

--- a/tests/test_hypothesis_plots.py
+++ b/tests/test_hypothesis_plots.py
@@ -250,5 +250,10 @@ def test_plot_ess(datatree, kind, relative, rug, n_points, extra_methods, min_es
     for key, value in plot_kwargs.items():
         if value is False:
             assert all(key not in child for child in pc.viz.children.values())
+        elif key == "rug":
+            if rug is False:
+                assert all(key not in child for child in pc.viz.children.values())
+            else:
+                assert all(key in child for child in pc.viz.children.values())
         elif key != "remove_axis":
             assert all(key in child for child in pc.viz.children.values())

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -8,6 +8,7 @@ from arviz_base import from_dict
 from arviz_plots import (
     plot_compare,
     plot_dist,
+    plot_ess,
     plot_forest,
     plot_ridge,
     plot_trace,
@@ -291,3 +292,51 @@ class TestPlots:
             pc_kwargs={"plot_grid_kws": {"figsize": (1000, 200)}},
             backend=backend,
         )
+
+    def test_plot_ess(self, datatree, backend):
+        pc = plot_ess(datatree, backend=backend, rug=True)
+        assert "chart" in pc.viz.data_vars
+        assert "plot" not in pc.viz.data_vars
+        assert "ess" in pc.viz["mu"]
+        assert "min_ess" in pc.viz["mu"]
+        assert "title" in pc.viz["mu"]
+        assert "rug" in pc.viz["mu"]
+        assert "hierarchy" not in pc.viz["mu"].dims
+        assert "hierarchy" in pc.viz["theta"].dims
+        assert pc.viz["mu"].rug.shape == (4,)  # checking rug artist shape (4 chains overlaid)
+        # checking aesthetics
+        assert "overlay" in pc.aes["mu"].data_vars  # overlay of chains
+
+    a = """
+    def test_plot_ess_sample(self, datatree_sample, backend):
+        pc = plot_ess(datatree_sample, backend=backend, rug=True, sample_dims="sample")
+        assert "chart" in pc.viz.data_vars
+        assert "plot" not in pc.viz.data_vars
+        assert "ess" in pc.viz["mu"]
+        assert "min_ess" in pc.viz["mu"]
+        assert "title" in pc.viz["mu"]
+        assert "rug" in pc.viz["mu"]
+        assert "hierarchy" not in pc.viz["mu"].dims
+        assert "hierarchy" in pc.viz["theta"].dims
+        assert pc.viz["mu"].trace.shape == ()  # 0 chains here, so no overlay
+    """  # error when running this: ValueError: dims must be of length 2 (from arviz-stats )
+    if a:
+        print("a")  # just to temporarily suspend linting error
+
+    def test_plot_ess_models(self, datatree, datatree2, backend):
+        pc = plot_ess({"c": datatree, "n": datatree2}, backend=backend, rug=False)
+        assert "chart" in pc.viz.data_vars
+        assert "plot" not in pc.viz.data_vars
+        assert "ess" in pc.viz["mu"]
+        assert "min_ess" in pc.viz["mu"]
+        assert "title" in pc.viz["mu"]
+        # assert "rug" in pc.viz["mu"]
+        assert "hierarchy" not in pc.viz["mu"].dims
+        assert "hierarchy" in pc.viz["theta"].dims
+        assert "model" in pc.viz["mu"].dims
+        # assert pc.viz["mu"].rug.shape == (2, 4)  # since there are 2 Ms, 4 Cs in datatree
+        # checking aesthetics
+        assert "model" in pc.aes["mu"].dims
+        assert "x" in pc.aes["mu"].data_vars
+        assert "color" in pc.aes["mu"].data_vars
+        assert "overlay" in pc.aes["mu"].data_vars  # overlay of chains

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -303,7 +303,7 @@ class TestPlots:
         assert "rug" in pc.viz["mu"]
         assert "hierarchy" not in pc.viz["mu"].dims
         assert "hierarchy" in pc.viz["theta"].dims
-        assert pc.viz["mu"].rug.shape == (4,)  # checking rug artist shape (4 chains overlaid)
+        assert "chain" in pc.viz["mu"].rug.dims  # checking rug artist overlay
         # checking aesthetics
         assert "overlay" in pc.aes["mu"].data_vars  # overlay of chains
 
@@ -330,11 +330,10 @@ class TestPlots:
         assert "ess" in pc.viz["mu"]
         assert "min_ess" in pc.viz["mu"]
         assert "title" in pc.viz["mu"]
-        # assert "rug" in pc.viz["mu"]
+        assert "rug" not in pc.viz["mu"]
         assert "hierarchy" not in pc.viz["mu"].dims
         assert "hierarchy" in pc.viz["theta"].dims
         assert "model" in pc.viz["mu"].dims
-        # assert pc.viz["mu"].rug.shape == (2, 4)  # since there are 2 Ms, 4 Cs in datatree
         # checking aesthetics
         assert "model" in pc.aes["mu"].dims
         assert "x" in pc.aes["mu"].data_vars

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -111,7 +111,7 @@ def cmp():
 
 
 @pytest.mark.parametrize("backend", ["matplotlib", "bokeh", "plotly", "none"])
-class TestPlots:
+class TestPlots:  # pylint: disable=too-many-public-methods
     @pytest.mark.parametrize("kind", ["kde", "hist", "ecdf"])
     def test_plot_dist(self, datatree, backend, kind):
         pc = plot_dist(datatree, backend=backend, kind=kind)

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -307,7 +307,6 @@ class TestPlots:  # pylint: disable=too-many-public-methods
         # checking aesthetics
         assert "overlay" in pc.aes["mu"].data_vars  # overlay of chains
 
-    a = """
     def test_plot_ess_sample(self, datatree_sample, backend):
         pc = plot_ess(datatree_sample, backend=backend, rug=True, sample_dims="sample")
         assert "chart" in pc.viz.data_vars
@@ -318,10 +317,7 @@ class TestPlots:  # pylint: disable=too-many-public-methods
         assert "rug" in pc.viz["mu"]
         assert "hierarchy" not in pc.viz["mu"].dims
         assert "hierarchy" in pc.viz["theta"].dims
-        assert pc.viz["mu"].trace.shape == ()  # 0 chains here, so no overlay
-    """  # error when running this: ValueError: dims must be of length 2 (from arviz-stats )
-    if a:
-        print("a")  # just to temporarily suspend linting error
+        assert pc.viz["mu"].rug.shape == ()  # 0 chains here, so no overlay
 
     def test_plot_ess_models(self, datatree, datatree2, backend):
         pc = plot_ess({"c": datatree, "n": datatree2}, backend=backend, rug=False)


### PR DESCRIPTION
Adding ESS plot (#5 ) 

Currently implemented for kind='local' only, using the new `scatter_xy` visual element function also added as part of this commit. The ess data ('y' values) obtained from the ess statistical computation via Arviz-Stats is combined with xdata ('x' values) generated via `np.linspace` (like the legacy ess plot in old Arviz does) after this xdata is broadcasted to fit the shape of the ess data. These are concatenated along a new plot_axis dimension (coords 'x' and 'y') which the `scatter_xy` visual element function then splits and plots accordingly. 

### Outputs:

`azp.plot_ess(data)`
![image](https://github.com/arviz-devs/arviz-plots/assets/24991131/0b76930a-ff8f-4523-9091-d58c8a542121)

`azp.plot_ess(data, var_names=["mu", "tau"])`
![image](https://github.com/arviz-devs/arviz-plots/assets/24991131/b7c47960-62fc-4053-9f24-8d4ff4ff8fe9)




<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--58.org.readthedocs.build/en/58/

<!-- readthedocs-preview arviz-plots end -->