### PR TITLE
Adding New Rootogram Plot 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dynamic = ["version", "description"]
 dependencies = [
   "arviz-base==0.2",
-  "arviz-stats[xarray]==0.2",
+  "arviz-stats[xarray] @ git+https://github.com/arviz-devs/arviz-stats@get_bins",
 ]
 
 [tool.flit.module]

--- a/src/arviz_plots/backend/matplotlib/__init__.py
+++ b/src/arviz_plots/backend/matplotlib/__init__.py
@@ -215,10 +215,8 @@ def hist(
     """Interface to matplotlib for a histogram bar plot."""
     artist_kws.setdefault("zorder", 2)
     widths = np.asarray(r_e) - np.asarray(l_e)
-    if np.any(bottom != 0):
-        height = y - bottom
-    else:
-        height = y
+    if bottom != 0:
+        y = y - bottom  # making y the top coordinate and not height
     if color is not unset:
         if facecolor is unset:
             facecolor = color
@@ -226,7 +224,7 @@ def hist(
             edgecolor = color
     kwargs = {"bottom": bottom, "color": facecolor, "edgecolor": edgecolor, "alpha": alpha}
     return target.bar(
-        l_e, height, width=widths, align="edge", **_filter_kwargs(kwargs, None, artist_kws)
+        l_e, y, width=widths, align="edge", **_filter_kwargs(kwargs, None, artist_kws)
     )
 
 

--- a/src/arviz_plots/backend/matplotlib/__init__.py
+++ b/src/arviz_plots/backend/matplotlib/__init__.py
@@ -215,7 +215,7 @@ def hist(
     """Interface to matplotlib for a histogram bar plot."""
     artist_kws.setdefault("zorder", 2)
     widths = np.asarray(r_e) - np.asarray(l_e)
-    if bottom != 0:
+    if np.any(bottom != 0):
         y = y - bottom  # making y the top coordinate and not height
     if color is not unset:
         if facecolor is unset:

--- a/src/arviz_plots/backend/none/__init__.py
+++ b/src/arviz_plots/backend/none/__init__.py
@@ -189,29 +189,6 @@ def _filter_kwargs(kwargs, artist_kws):
     return {**artist_kws, **kwargs}
 
 
-def hist(
-    y, l_e, r_e, target, *, bottom=None, color=unset, facecolor=unset, edgecolor=unset, **artist_kws
-):
-    """Interface to matplotlib for a histogram bar plot."""
-    if not ALLOW_KWARGS and artist_kws:
-        raise ValueError("artist_kws not empty")
-    if color is not unset:
-        if facecolor is unset:
-            facecolor = color
-        if edgecolor is unset:
-            edgecolor = color
-    kwargs = {"bottom": bottom, "facecolor": facecolor, "edgecolor": edgecolor}
-    artist_element = {
-        "function": "hist",
-        "l_e": np.atleast_1d(l_e),
-        "r_e": np.atleast_1d(r_e),
-        "y": np.atleast_1d(y),
-        **_filter_kwargs(kwargs, artist_kws),
-    }
-    target.append(artist_element)
-    return artist_element
-
-
 # "geoms"
 def hist(
     y, l_e, r_e, target, *, bottom=None, color=unset, facecolor=unset, edgecolor=unset, **artist_kws

--- a/src/arviz_plots/backend/none/__init__.py
+++ b/src/arviz_plots/backend/none/__init__.py
@@ -191,7 +191,17 @@ def _filter_kwargs(kwargs, artist_kws):
 
 # "geoms"
 def hist(
-    y, l_e, r_e, target, *, bottom=None, color=unset, facecolor=unset, edgecolor=unset, **artist_kws
+    y,
+    l_e,
+    r_e,
+    target,
+    *,
+    bottom=None,
+    color=unset,
+    alpha=unset,
+    facecolor=unset,
+    edgecolor=unset,
+    **artist_kws,
 ):
     """Interface to matplotlib for a histogram bar plot."""
     if not ALLOW_KWARGS and artist_kws:
@@ -201,7 +211,7 @@ def hist(
             facecolor = color
         if edgecolor is unset:
             edgecolor = color
-    kwargs = {"bottom": bottom, "facecolor": facecolor, "edgecolor": edgecolor}
+    kwargs = {"bottom": bottom, "alpha": alpha, "facecolor": facecolor, "edgecolor": edgecolor}
     artist_element = {
         "function": "hist",
         "l_e": np.atleast_1d(l_e),

--- a/src/arviz_plots/backend/none/__init__.py
+++ b/src/arviz_plots/backend/none/__init__.py
@@ -213,6 +213,29 @@ def hist(
 
 
 # "geoms"
+def hist(
+    y, l_e, r_e, target, *, bottom=None, color=unset, facecolor=unset, edgecolor=unset, **artist_kws
+):
+    """Interface to matplotlib for a histogram bar plot."""
+    if not ALLOW_KWARGS and artist_kws:
+        raise ValueError("artist_kws not empty")
+    if color is not unset:
+        if facecolor is unset:
+            facecolor = color
+        if edgecolor is unset:
+            edgecolor = color
+    kwargs = {"bottom": bottom, "facecolor": facecolor, "edgecolor": edgecolor}
+    artist_element = {
+        "function": "hist",
+        "l_e": np.atleast_1d(l_e),
+        "r_e": np.atleast_1d(r_e),
+        "y": np.atleast_1d(y),
+        **_filter_kwargs(kwargs, artist_kws),
+    }
+    target.append(artist_element)
+    return artist_element
+
+
 def line(x, y, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
     """Interface to a line plot."""
     kwargs = {"color": color, "alpha": alpha, "width": width, "linestyle": linestyle}

--- a/src/arviz_plots/plots/__init__.py
+++ b/src/arviz_plots/plots/__init__.py
@@ -4,6 +4,7 @@ from .compareplot import plot_compare
 from .distplot import plot_dist
 from .forestplot import plot_forest
 from .ridgeplot import plot_ridge
+from .rootogramplot import plot_rootogram
 from .tracedistplot import plot_trace_dist
 from .traceplot import plot_trace
 
@@ -14,4 +15,5 @@ __all__ = [
     "plot_trace",
     "plot_trace_dist",
     "plot_ridge",
+    "plot_rootogram",
 ]

--- a/src/arviz_plots/plots/distplot.py
+++ b/src/arviz_plots/plots/distplot.py
@@ -1,4 +1,5 @@
 """dist plot code."""
+
 import warnings
 from copy import copy
 from importlib import import_module
@@ -358,7 +359,9 @@ def plot_dist(
             point_density_diff = [
                 dim for dim in density.sel(plot_axis="histogram").dims if dim not in point.dims
             ]
-            point_density_diff = ["hist_dim"] + point_density_diff
+            point_density_diff = [
+                f"hist_dim_{var_name}" for var_name in density.data_vars
+            ] + point_density_diff
             point_y = 0.04 * density.sel(plot_axis="histogram", drop=True).max(
                 dim=point_density_diff
             )

--- a/src/arviz_plots/plots/rootogramplot.py
+++ b/src/arviz_plots/plots/rootogramplot.py
@@ -204,6 +204,10 @@ def plot_rootogram(
         coords=coords,
     )
 
+    # print(f"\n sample_dims = {sample_dims}")
+    # print(f"\n facet_dims = {facet_dims}")
+    # print(f"\n reduce_dims = {reduce_dims}")
+
     # ---------(observed data)-----------
     # observed data calculations are made outside of and before observed artist plotting since
     # predictive also depends on this computed data (number of bins and top of predictive bars
@@ -362,10 +366,6 @@ def plot_rootogram(
             labeller=labeller,
             **title_kwargs,
         )
-
-    # print(f"\nsample_dims = {sample_dims}")
-    # print(f"\nfacet_dims = {facet_dims}")
-    # print(f"\nreduce_dims = {reduce_dims}")
 
     # print(f"\n-----------------------------------------------------------------\n")
     # print(f"\n datatree = {dt}")

--- a/src/arviz_plots/plots/rootogramplot.py
+++ b/src/arviz_plots/plots/rootogramplot.py
@@ -311,7 +311,7 @@ def plot_rootogram(
             linestyle = plot_bknd.get_default_aes("linestyle", 2, {})[1]
 
             if "linestyle" not in obs_line_aes:
-                obs_kwargs.setdefault("linestyle", linestyle)
+                obs_line_kwargs.setdefault("linestyle", linestyle)
 
             if "color" not in obs_line_aes:
                 obs_line_kwargs.setdefault("color", "black")

--- a/src/arviz_plots/plots/rootogramplot.py
+++ b/src/arviz_plots/plots/rootogramplot.py
@@ -85,6 +85,7 @@ def plot_rootogram(
         * "observed" -> passed to :func: `~arviz_plots.visuals.scatter_xy`
         * "observed_line" -> passed to :func:`~arviz_plots.visuals.line_xy`
         * "observed_rug" -> passed to :func:`arviz_plots.visuals.trace_rug`
+        * "baseline" -> passed to :func:`~arviz_plots.visuals.line_xy`
         * "title" -> passed to :func:`~arviz_plots.visuals.labelled_title`
         * "remove_axis" -> not passed anywhere, can only be ``False`` to skip calling this function
     stats_kwargs : mapping, optional

--- a/src/arviz_plots/plots/rootogramplot.py
+++ b/src/arviz_plots/plots/rootogramplot.py
@@ -1,0 +1,469 @@
+"""rootogram plot code."""
+
+from copy import copy
+from importlib import import_module
+
+import arviz_stats  # pylint: disable=unused-import
+import numpy as np
+import xarray as xr
+from arviz_base import rcParams
+from arviz_base.labels import BaseLabeller
+from arviz_stats.base import array_stats
+
+from arviz_plots.plot_collection import PlotCollection
+from arviz_plots.plots.utils import filter_aes, process_group_variables_coords
+from arviz_plots.visuals import hist, labelled_title, line_xy, scatter_xy, trace_rug
+
+
+def plot_rootogram(
+    dt,
+    var_names=None,
+    filter_vars=None,
+    group="posterior",
+    observed=None,
+    observed_rug=False,
+    coords=None,
+    sample_dims=None,
+    facet_dims=None,
+    data_pairs=None,
+    plot_collection=None,
+    backend=None,
+    labeller=None,
+    aes_map=None,
+    plot_kwargs=None,
+    stats_kwargs=None,
+    pc_kwargs=None,
+):
+    """Plot discrete prior/posterior predictive and observed values as rootogram plots.
+
+    Parameters
+    ----------
+    dt : DataTree
+        Input data with observed_data and prior/posterior predictive data.
+    var_names : str or list of str, optional
+        One or more variables to be plotted.
+        Prefix the variables by ~ when you want to exclude them from the plot.
+    filter_vars : {None, “like”, “regex”}, default=None
+        If None, interpret var_names as the real variables names.
+        If “like”, interpret var_names as substrings of the real variables names.
+        If “regex”, interpret var_names as regular expressions on the real variables names.
+    group : str, default "posterior"
+        Group to be plotted. Note: Posterior refers to posterior-predictive, prior refers to
+        prior-predictive.
+    observed : boolean, optional
+        Whether or not to plot the observed data. Defaults to True for ``group = posterior``
+        and False for ``group = prior``.
+    observed_rug : boolean, default False
+        Whether or not to plot a rug plot of the observed data. Only valid if observed=True.
+    coords : dict, optional
+        Dictionary mapping dimensions to selected coordinates to be plotted.
+        Dimensions without a mapping specified will include all coordinates for that dimension.
+        Defaults to including all coordinates for all dimensions if None.
+    sample_dims : str or sequence of hashable, optional
+        Dimensions to reduce unless mapped to an aesthetic.
+        Note: Dims not in sample_dims or facet_dims (below) will also be reduced by default.
+        Defaults to ``rcParams["data.sample_dims"]``
+    facet_dims : list, optional
+        Dimensions to facet over (for which multiple plots will be generated).
+        Defaults to empty list.
+    data_pairs : dict, optional
+        Dictionary containing relations between observed data and posterior/prior predictive data.
+        Dictionary keys are variable names corresponding to observed data and dictionary values
+        are variable names corresponding to posterior/prior predictive.
+        For example, data_pairs = {'y' : 'y_hat'}.
+        By default, it will assume that the observed data and the posterior/prior predictive data
+        have the same variable names
+    plot_collection : PlotCollection, optional
+    backend : {"matplotlib", "bokeh"}, optional
+    labeller : labeller, optional
+    aes_map : mapping of {str : sequence of str}, optional
+        Mapping of artists to aesthetics that should use their mapping in `plot_collection`
+        when plotted. Valid keys are the same as for `plot_kwargs`.
+    plot_kwargs : mapping of {str : mapping or False}, optional
+        Valid keys are:
+        * "predictive" -> Passed to :func:`~arviz_plots.visuals.hist_line`
+        * "observed" -> passed to :func: `~arviz_plots.visuals.scatter_xy`
+        * "observed_line" -> passed to :func:`~arviz_plots.visuals.line_xy`
+        * "observed_rug" -> passed to :func:`arviz_plots.visuals.trace_rug`
+        * "title" -> passed to :func:`~arviz_plots.visuals.labelled_title`
+        * "remove_axis" -> not passed anywhere, can only be ``False`` to skip calling this function
+    stats_kwargs : mapping, optional
+        Valid keys are:
+        * predictive -> passed to hist
+        * observed -> passed to hist
+    pc_kwargs : mapping
+        Passed to :class:`arviz_plots.PlotCollection.wrap`
+    Returns
+    -------
+    PlotCollection
+    Examples
+    --------
+    WIP
+    """
+    if sample_dims is None:
+        sample_dims = rcParams["data.sample_dims"]
+    if isinstance(sample_dims, str):
+        sample_dims = [sample_dims]
+    if plot_kwargs is None:
+        plot_kwargs = {}
+    if pc_kwargs is None:
+        pc_kwargs = {}
+    else:
+        pc_kwargs = pc_kwargs.copy()
+
+    if stats_kwargs is None:
+        stats_kwargs = {}
+    if facet_dims is None:
+        facet_dims = []
+
+    # check for duplication of facet_dims in top level arg input and pc_kwargs
+    if "cols" in pc_kwargs and len(facet_dims) > 0:
+        raise ValueError(
+            f"""Facet dimensions have been defined twice.
+                Please pick only one of `facet_dims` or `pc_kwargs['cols']`.
+                Currently defined facet_dims = {facet_dims}
+                Currently defined pc_kwargs['cols'] = {pc_kwargs["cols"]}"""
+        )
+
+    if group not in ("posterior", "prior"):
+        raise TypeError("`group` argument must be either `posterior` or `prior`")
+
+    predictive_data_group = f"{group}_predictive"
+    if observed is None:
+        observed = group == "posterior"  # by default true if posterior, false if prior
+
+    # checking to make sure plot_kwargs["observed"] is not False
+    observed_kwargs = copy(plot_kwargs.get("observed", {}))
+    if observed_kwargs is False:
+        raise ValueError(
+            """plot_kwargs['observed'] can't be False, use observed=False to remove observed 
+            plot element"""
+        )
+
+    # making sure both posterior/prior predictive group and observed_data group exists in
+    # datatree provided
+    if observed:
+        for group_name in (predictive_data_group, "observed_data"):
+            if group_name not in dt.children:
+                raise TypeError(f'`data` argument must have the group "{group_name}" for ppcplot')
+    else:
+        if f"{predictive_data_group}" not in dt.children:
+            raise TypeError(f'`data` argument must have the group "{group}_predictive" for ppcplot')
+
+    # initializaing data_pairs as empty dict in case pp and observed data var names are same
+    if data_pairs is None:
+        data_pairs = {}
+
+    if backend is None:
+        if plot_collection is None:
+            backend = rcParams["plot.backend"]
+        else:
+            backend = plot_collection.backend
+
+    # getting plot backend to get default linestyles to put in default kwargs for visual elements
+    plot_bknd = import_module(f".backend.{backend}", package="arviz_plots")
+
+    # pp distribution group plotting logic
+    pp_distribution = process_group_variables_coords(
+        dt,
+        group=predictive_data_group,
+        var_names=(
+            None
+            if var_names is None
+            else [data_pairs.get(var_name, var_name) for var_name in var_names]
+        ),
+        filter_vars=filter_vars,
+        coords=coords,
+    )
+    # print(f"\npp_distribution = {pp_distribution}")
+
+    total_pp_samples = np.prod(
+        [pp_distribution.sizes[dim] for dim in sample_dims if dim in pp_distribution.dims]
+    )
+
+    # wrap plot collection with pp distribution
+    if plot_collection is None:
+        pc_kwargs.setdefault("col_wrap", 5)
+        pc_kwargs.setdefault(
+            "cols",
+            ["__variable__"]  # special variable to create one plot per variable
+            + list(facet_dims),  # making sure multiple plots are created for each facet dim
+        )
+        pc_kwargs["aes"] = pc_kwargs.get("aes", {}).copy()
+        pc_kwargs["aes"].setdefault("overlay", sample_dims)  # setting overlay dim
+        plot_collection = PlotCollection.wrap(
+            pp_distribution,
+            backend=backend,
+            **pc_kwargs,
+        )
+    # set reduce_dims by elimination
+    reduce_dims = [
+        dim for dim in pp_distribution.dims if dim not in set(facet_dims).union(set(sample_dims))
+    ]
+
+    if aes_map is None:
+        aes_map = {}
+    else:
+        aes_map = aes_map.copy()
+    aes_map.setdefault("predictive", plot_collection.aes_set)
+    if labeller is None:
+        labeller = BaseLabeller()
+
+    # setting plot_kwargs_dist defaults (for passing to internal plot_dist calls)
+    plot_kwargs_dist = {
+        key: False
+        for key in ("credible_interval", "point_estimate", "point_estimate_text", "title")
+    }
+    # if "remove_axis" in plot_kwargs:
+    plot_kwargs_dist["remove_axis"] = False  # plot_kwargs["remove_axis"]
+
+    # print(f"\n aes_map = {aes_map}")
+
+    # obs distribution calculated outside `if observed` since plotting predictive bars requires it
+    observed_data_group = "observed_data"
+    obs_distribution = process_group_variables_coords(
+        dt,
+        group=observed_data_group,
+        var_names=var_names,
+        filter_vars=filter_vars,
+        coords=coords,
+    )
+    # print(f"\n obs_distribution = {obs_distribution}")
+
+    # ---------(observed data)-----------
+    # observed data calculations are made outside of and before 'if observed' since predictive also
+    # depends on this computed data (number of bins and top of predictive bars for rootograms)
+
+    # use get_bins func from arviz-stats on observed data and then use those bins for
+    # computing histograms for predictive data as well
+    # WIP: currently only the bins for one variable (without any facetting) is retrieved and used
+    bins = array_stats.get_bins(obs_distribution["home_points"].values)
+    print(f"\n bins = {bins}")
+
+    # this portion is situated in an out of convention spot becuse obs_hist_dims is required
+    obs_hist_dims, obs_hist_aes, obs_hist_ignore = filter_aes(
+        plot_collection, aes_map, "observed", reduce_dims
+    )
+
+    obs_stats_kwargs = copy(stats_kwargs.get("observed", {}))
+    obs_stats_kwargs.setdefault("bins", bins)
+
+    obs_hist = obs_distribution.azstats.histogram(
+        dims=list(obs_hist_dims) + list(sample_dims), **obs_stats_kwargs
+    )
+
+    # print(f"\n obs_hist = {obs_hist}")
+
+    obs_hist.loc[{"plot_axis": "histogram"}] = (obs_hist.sel(plot_axis="histogram")) ** 0.5
+
+    # print(f"\n obs_density.data_vars = {obs_density.data_vars}")
+    # print(f"\n obs_density.keys() = {obs_density.keys()}")
+
+    # new_obs_hist with histogram->y and left_edge/right_edge midpoint->x
+    new_obs_hist = xr.Dataset()
+
+    for var_name in list(obs_hist.keys()):
+        left_edges = obs_hist[var_name].sel(plot_axis="left_edges").values
+        right_edges = obs_hist[var_name].sel(plot_axis="right_edges").values
+
+        left_edges = np.array(left_edges)
+        right_edges = np.array(right_edges)
+
+        # print(f"\n left_edges = {left_edges}")
+        # print(f"\n right_edges = {right_edges}")
+
+        x = (left_edges + right_edges) / 2
+        y = obs_hist[var_name].sel(plot_axis="histogram").values
+
+        # print(f"\n new_obs_hist y= {y}")
+        # print(f"x = {x} | y = {y}")
+
+        stacked_data = np.stack((x, y), axis=-1)
+        new_var = xr.DataArray(
+            stacked_data, dims=["hist_dim", "plot_axis"], coords={"plot_axis": ["x", "y"]}
+        )
+
+        new_obs_hist[var_name] = new_var
+
+    print(f"\n new_obs_hist = {new_obs_hist}")
+
+    if observed:  # all observed data group plotting logic happens here
+        obs_kwargs = copy(plot_kwargs.get("observed", {}))
+        if obs_kwargs is not False:
+            if "color" not in obs_hist_aes:
+                obs_kwargs.setdefault("color", "black")
+
+            plot_collection.map(
+                scatter_xy,
+                "observed",
+                data=new_obs_hist,
+                ignore_aes=obs_hist_ignore,
+                **obs_kwargs,
+            )
+
+        obs_line_kwargs = copy(plot_kwargs.get("observed_line", {}))
+        if obs_line_kwargs is not False:
+            _, obs_line_aes, obs_line_ignore = filter_aes(
+                plot_collection, aes_map, "observed", reduce_dims
+            )
+
+            linestyle = plot_bknd.get_default_aes("linestyle", 2, {})[1]
+
+            if "linestyle" not in obs_line_aes:
+                obs_kwargs.setdefault("linestyle", linestyle)
+
+            if "color" not in obs_line_aes:
+                obs_line_kwargs.setdefault("color", "black")
+
+            plot_collection.map(
+                line_xy,
+                "observed_line",
+                data=new_obs_hist,
+                ignore_aes=obs_line_ignore,
+                **obs_line_kwargs,
+            )
+
+        # ---------(observed rug plot)-----------
+        if observed_rug:
+            # plot observed density as a rug
+            rug_kwargs = copy(plot_kwargs.get("observed_rug", {}))
+
+            _, rug_aes, rug_ignore = filter_aes(
+                plot_collection, aes_map, "observed_rug", reduce_dims
+            )
+            if "color" not in rug_aes:
+                rug_kwargs.setdefault("color", "black")
+            if "marker" not in rug_aes:
+                rug_kwargs.setdefault("marker", "|")
+            if "size" not in rug_aes:
+                rug_kwargs.setdefault("size", 30)
+
+            # print(f"\nobs_distribution = {obs_distribution}")
+
+            plot_collection.map(
+                trace_rug,
+                "observed_rug",
+                data=obs_distribution,
+                ignore_aes=rug_ignore,
+                xname=False,
+                y=0,
+                **rug_kwargs,
+            )
+
+    # ---------(PPC data)-------------
+
+    pp_kwargs = copy(plot_kwargs.get("predictive", {}))
+
+    if pp_kwargs is not False:
+        pp_hist_dims, pp_hist_aes, pp_hist_ignore = filter_aes(
+            plot_collection, aes_map, "predictive", reduce_dims
+        )
+        # getting first default color from color cycle and picking it
+        pp_default_color = plot_bknd.get_default_aes("color", 1, {})[0]
+        if "color" not in pp_hist_aes:
+            pp_kwargs.setdefault("color", pp_default_color)
+
+        if "alpha" not in pp_hist_aes:
+            pp_kwargs.setdefault("alpha", 0.2)
+
+        pp_stats_kwargs = copy(stats_kwargs.get("predictive", {}))
+        pp_stats_kwargs.setdefault("bins", bins)
+
+        pp_hist = pp_distribution.azstats.histogram(
+            dims=list(pp_hist_dims) + list(sample_dims), **pp_stats_kwargs
+        )
+
+        # print(f"\n pp_density histogram form pp_hist = {pp_hist}")
+
+        # the top of the predictive bars height = the observed height for that bin
+        # the bottom = difference between observed and predictive height for that bin
+
+        # getting mean of counts across all predictive samples and taking its square root
+        pp_hist.loc[{"plot_axis": "histogram"}] = (
+            pp_hist.sel(plot_axis="histogram") / total_pp_samples
+        ) ** 0.5
+
+        # new_pp_hist dataset
+        new_pp_hist = xr.Dataset()
+
+        for var_name in list(pp_hist.keys()):
+            left_edges = pp_hist[var_name].sel(plot_axis="left_edges").values
+            right_edges = pp_hist[var_name].sel(plot_axis="right_edges").values
+
+            # getting top of histogram (observed values dataset's 'y' coord)
+            new_histogram = new_obs_hist[var_name].sel(plot_axis="y").values
+            print(f"\n new_pp_hist (new_histogram) observed heights= {new_histogram}")
+
+            histogram_bottom = new_histogram - pp_hist[var_name].sel(plot_axis="histogram").values
+            # print(f"\n new_pp_hist histogram_bottom= {histogram_bottom}")
+
+            stacked_data = np.stack(
+                (new_histogram, left_edges, right_edges, histogram_bottom), axis=-1
+            )
+            new_var = xr.DataArray(
+                stacked_data,
+                dims=["hist_dim", "plot_axis"],
+                coords={
+                    "plot_axis": ["histogram", "left_edges", "right_edges", "histogram_bottom"]
+                },
+            )
+
+            new_pp_hist[var_name] = new_var
+
+        print(f"\n new_pp_hist = {new_pp_hist}")
+
+        plot_collection.map(
+            hist, "predictive", data=new_pp_hist, ignore_aes=pp_hist_ignore, **pp_kwargs
+        )
+
+    # adding baseline at 0
+    baseline_kwargs = copy(plot_kwargs.get("baseline", {}))
+    if baseline_kwargs is not False:
+        _, baseline_aes, baseline_ignore = filter_aes(
+            plot_collection, aes_map, "baseline", reduce_dims
+        )
+
+        linestyle = plot_bknd.get_default_aes("linestyle", 2, {})[1]
+
+        if "linestyle" not in baseline_aes:
+            baseline_kwargs.setdefault("linestyle", linestyle)
+
+        if "color" not in baseline_aes:
+            baseline_kwargs.setdefault("color", "black")
+
+        plot_collection.map(
+            line_xy,
+            "baseline",
+            data=obs_distribution,
+            x=bins,
+            y=0,
+            ignore_aes=baseline_ignore,
+            **baseline_kwargs,
+        )
+
+    # adding plot title/s
+    title_kwargs = copy(plot_kwargs.get("title", {}))
+    if title_kwargs is not False:
+        _, title_aes, title_ignore = filter_aes(plot_collection, aes_map, "title", sample_dims)
+        if "color" not in title_aes:
+            title_kwargs.setdefault("color", "black")
+        plot_collection.map(
+            labelled_title,
+            "title",
+            ignore_aes=title_ignore,
+            subset_info=True,
+            labeller=labeller,
+            **title_kwargs,
+        )
+
+    # print(f"\nsample_dims = {sample_dims}")
+    # print(f"\nfacet_dims = {facet_dims}")
+    # print(f"\nreduce_dims = {reduce_dims}")
+
+    # print(f"\n-----------------------------------------------------------------\n")
+    # print(f"\n datatree = {dt}")
+    # print(f"\n pc.viz = {plot_collection.viz!r}")
+    # print(f"\n pc.aes = {plot_collection.aes!r}")
+    # print(f"\n-----------------------------------------------------------------\n")
+
+    return plot_collection


### PR DESCRIPTION
Pushed draft of the new Rootogram implementation code (#52 ) . 

- The existing hist functions from the currently still-open plot_dist hist addition PR #47 were used here as well as some code from the plot_ppc PR #55. 

- The hist visual element backend interface docstring was modified with 'y' now referring to the 'top' y-coordinate explicitly and not height of the bars (as suggested by @OriolAbril). The matplotlib implementation of the hist visual element (which uses `bar` behind the scenes) was also updated internally with `y=y-bottom` to reflect this. (This has to be updated in #47 now as well). The bars were not being plotted in the expected positions otherwise.

- WIP work includes appropriate binning for each facetted subset of the data to be plotted. 

- The observed data is used for binning for each subset and the bin heights here are required for setting the 'top's of the predictive bars so this is computed always, regardless of whether `observed` is passed as True or False (The True/False condition only determines whether it is plotted or not)

Current plot output when the `rugby` default Arviz datatree is passed (should work with any datatree with posterior predictive and observed groups like plot_ppc though): 


`azp.plot_rootogram(data)`
![image](https://github.com/user-attachments/assets/386f1da7-aa3a-4610-9b47-9e32c2fe1186)


`azp.plot_rootogram(data, plot_kwargs={"predictive": False})`
![image](https://github.com/user-attachments/assets/73741e28-b8c2-4a60-8da3-0c0b05f20cb4)

`azp.plot_rootogram(data, observed=False)`
![image](https://github.com/user-attachments/assets/66807809-9aa9-4404-882f-5cd242171499)

```
pc = azp.plot_rootogram(data, backend="bokeh")
pc.show()
```
![image](https://github.com/user-attachments/assets/e241e708-7d70-4964-ab25-f057c56ce403)


`azp.plot_rootogram(data, observed_rug=True)`
![image](https://github.com/user-attachments/assets/93f0cf92-56c3-49b0-95d0-ce4be1ab1f9c)

^If we want a rugplot for rootograms as well like plot_ppc.







<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--81.org.readthedocs.build/en/81/

<!-- readthedocs-preview arviz-plots end -->