### PR TITLE
rework styles 

### DIFF
--- a/src/arviz_plots/backend/plotly/templates.py
+++ b/src/arviz_plots/backend/plotly/templates.py
@@ -12,14 +12,14 @@ arviz_clean_template.layout.xaxis = axis_common
 arviz_clean_template.layout.yaxis = axis_common
 
 arviz_clean_template.layout.colorway = [
-    "#1a6587",
-    "#a6ccfe",
-    "#f98d74",
-    "#f5e257",
-    "#e5441a",
-    "#5b8073",
-    "#b66edd",
-    "#9b403d",
-    "#969bab",
-    "#c1c1c1",
+    "#36acc6",
+    "#f66d7f",
+    "#fac364",
+    "#7c2695",
+    "#228306",
+    "#a252f4",
+    "#63f0ea",
+    "#000000",
+    "#6f6f6f",
+    "#b7b7b7",
 ]

--- a/src/arviz_plots/styles/arviz-cetrino.mplstyle
+++ b/src/arviz_plots/styles/arviz-cetrino.mplstyle
@@ -5,7 +5,7 @@
 figure.facecolor:   white   # broken white outside box
 figure.edgecolor:   None    # broken white outside box
 figure.titleweight: bold    # weight of the figure title
-figure.titlesize:   18
+figure.titlesize:   x-large
 
 figure.figsize:     6, 5
 figure.dpi:         200.0
@@ -15,6 +15,7 @@ figure.constrained_layout.use: True
 ## * FONT                                                                    *
 ## ***************************************************************************
 
+font.size:      12
 font.style:     normal
 font.variant:   normal
 font.weight:    normal
@@ -48,13 +49,13 @@ axes.spines.top:        False       # do not show top spine
 axes.titlesize:         16
 axes.titleweight:       bold        # font weight of title
 
-axes.labelsize:         14
+axes.labelsize:         large
 axes.labelcolor:        .15
 axes.labelweight:       normal      # weight of the x and y labels
 
 # color-blind friendly cycle designed using https://colorcyclepicker.mpetroff.net/
-# see preview and check for colorblindness here https://coolors.co/40a96d-a2157f-f62907-e4bf2b-32d2f9-9140f1-000000-6f6f6f-b7b7b7
-axes.prop_cycle: cycler(color=["40a96d", "a2157f", "f62907", "e4bf2b", "32d2f9", "9140f1", "000000", "6f6f6f", "b7b7b7"])
+# see preview and check for colorblindness here https://coolors.co/009988-9238b2-d2225f-ec8f26-fcd026-3cd186-a57119-2f5e14-f225f4-8f9fbf
+axes.prop_cycle: cycler(color=["009988", "9238b2", "d2225f", "ec8f26", "fcd026", "3cd186", "a57119", "2f5e14", "f225f4", "8f9fbf"])
 
 image.cmap: viridis
 
@@ -62,13 +63,13 @@ image.cmap: viridis
 ## * TICKS                                                                   *
 ## ***************************************************************************
 
-xtick.labelsize:    14
+xtick.labelsize:    large
 xtick.color:        .15
 xtick.top:          False
 xtick.bottom:       True
 xtick.direction:    out
 
-ytick.labelsize:    14
+ytick.labelsize:    large
 ytick.color:        .15
 ytick.left:         True
 ytick.right:        False
@@ -85,4 +86,4 @@ legend.fancybox:    False   # do not round corners
 legend.numpoints: 1
 legend.scatterpoints: 1
 
-legend.fontsize: 14
+legend.fontsize: large

--- a/src/arviz_plots/styles/arviz-clean.mplstyle
+++ b/src/arviz_plots/styles/arviz-clean.mplstyle
@@ -54,8 +54,8 @@ axes.labelcolor:        .15
 axes.labelweight:       normal      # weight of the x and y labels
 
 # color-blind friendly cycle designed using https://colorcyclepicker.mpetroff.net/
-# see preview and check for colorblindness here https://coolors.co/1a6587-a6ccfe-f98d74-f5e257-e5441a-5b8073-b66edd-9b403d-969bab-c1c1c1
-axes.prop_cycle: cycler(color=["1a6587",  "a6ccfe", "f98d74", "f5e257", "e5441a", "5b8073", "b66edd", "9b403d", "969bab", "c1c1c1"])
+# see preview and check for colorblindness here https://coolors.co/36acc6-f66d7f-fac364-7c2695-228306-a252f4-63f0ea-000000-6f6f6f-b7b7b7
+axes.prop_cycle: cycler(color=["36acc6", "f66d7f", "fac364", "7c2695", "228306", "a252f4", "63f0ea", "000000", "6f6f6f", "b7b7b7"])
 
 image.cmap: viridis
 
@@ -87,3 +87,4 @@ legend.numpoints: 1
 legend.scatterpoints: 1
 
 legend.fontsize: large
+

--- a/src/arviz_plots/styles/arviz-vibrant.mplstyle
+++ b/src/arviz_plots/styles/arviz-vibrant.mplstyle
@@ -5,7 +5,7 @@
 figure.facecolor:   white   # broken white outside box
 figure.edgecolor:   None    # broken white outside box
 figure.titleweight: bold    # weight of the figure title
-figure.titlesize:   18
+figure.titlesize:   x-large
 
 figure.figsize:     6, 5
 figure.dpi:         200.0
@@ -15,6 +15,7 @@ figure.constrained_layout.use: True
 ## * FONT                                                                    *
 ## ***************************************************************************
 
+font.size:      12
 font.style:     normal
 font.variant:   normal
 font.weight:    normal
@@ -48,27 +49,26 @@ axes.spines.top:        False       # do not show top spine
 axes.titlesize:         16
 axes.titleweight:       bold        # font weight of title
 
-axes.labelsize:         14
+axes.labelsize:         large
 axes.labelcolor:        .15
 axes.labelweight:       normal      # weight of the x and y labels
 
 # color-blind friendly cycle designed using https://colorcyclepicker.mpetroff.net/
-# see preview and check for colorblindness here https://coolors.co/36acc6-f66d7f-fcc770-96dacb-915ef2-17547d-578629-000000-6f6f6f-b7b7b7
-axes.prop_cycle: cycler(color=["36acc6", "f66d7f", "fcc770", "96dacb", "915ef2", "17547d", "578629", "000000", "6f6f6f", "b7b7b7"])
-
+# see preview and check for colorblindness here https://coolors.co/008b92-f15c58-48cdef-98d81a-997ee5-f5dc9d-c90a4e-145393-323232-616161
+axes.prop_cycle: cycler(color=["008b92", "f15c58", "48cdef", "98d81a", "997ee5", "f5dc9d", "c90a4e", "145393", "323232", "616161"])
 image.cmap: viridis
 
 ## ***************************************************************************
 ## * TICKS                                                                   *
 ## ***************************************************************************
 
-xtick.labelsize:    14
+xtick.labelsize:    large
 xtick.color:        .15
 xtick.top:          False
 xtick.bottom:       True
 xtick.direction:    out
 
-ytick.labelsize:    14
+ytick.labelsize:    large
 ytick.color:        .15
 ytick.left:         True
 ytick.right:        False
@@ -85,4 +85,4 @@ legend.fancybox:    False   # do not round corners
 legend.numpoints: 1
 legend.scatterpoints: 1
 
-legend.fontsize: 14
+legend.fontsize: large


### PR DESCRIPTION
Mostly changes to the colour palettes. I think these look better than the previous ones. The new "arviz-clean" is based on the old "arviz-clean_02". I also changed the names of "arviz-clean_01" and "arviz-clean_02". I keep the name "arviz-clean" to minimize changes. But we can change it too.

<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--88.org.readthedocs.build/en/88/

<!-- readthedocs-preview arviz-plots end -->