### PR TITLE
fix link to github

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -67,5 +67,5 @@ contributing/docs
 
 Twitter <https://twitter.com/arviz_devs>
 Mastodon <https://bayes.club/@ArviZ>
-GitHub repository <https://github.com/arviz-devs/xarray-einstats>
+GitHub repository <https://github.com/arviz-devs/arviz-plots>
 ```


### PR DESCRIPTION


<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--91.org.readthedocs.build/en/91/

<!-- readthedocs-preview arviz-plots end -->