### PR TITLE
Add plot for distribution of convergence diagnostics

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,8 @@ build:
 
 sphinx:
   fail_on_warning: true
+  configuration: docs/conf.py
+
 
 python:
    install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
 
 sphinx:
   fail_on_warning: true
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 
 python:

--- a/docs/source/api/plots.rst
+++ b/docs/source/api/plots.rst
@@ -18,6 +18,7 @@ A complementary introduction and guide to ``plot_...`` functions is available at
    :toctree: generated/
 
    plot_compare
+   plot_convergence_dist
    plot_dist
    plot_ess
    plot_ess_evolution

--- a/docs/source/api/visuals.rst
+++ b/docs/source/api/visuals.rst
@@ -17,6 +17,8 @@ Data plotting elements
    scatter_x
    scatter_xy
    ecdf_line
+   vline
+   hline
    hist
 
 Data and axis annotating elements

--- a/docs/source/gallery/inference_diagnostics/plot_convergence_dist.py
+++ b/docs/source/gallery/inference_diagnostics/plot_convergence_dist.py
@@ -6,7 +6,7 @@ Plot the distribution of ESS and R-hat.
 ---
 
 :::{seealso}
-API Documentation: {func}`~arviz_plots.plot_ess`
+API Documentation: {func}`~arviz_plots.plot_convergence_dist`
 :::
 """
 
@@ -17,9 +17,10 @@ import arviz_plots as azp
 azp.style.use("arviz-clean")
 
 data = load_arviz_data("radon")
-pc = azp.plot_convergence_dist(data,
-                               var_names=["za_county"],
-                               backend="none",  # change to preferred backend
+pc = azp.plot_convergence_dist(
+    data,
+    var_names=["za_county"],
+    backend="none",  # change to preferred backend
 )
 
 pc.show()

--- a/docs/source/gallery/inference_diagnostics/plot_convergence_dist.py
+++ b/docs/source/gallery/inference_diagnostics/plot_convergence_dist.py
@@ -1,0 +1,25 @@
+"""
+# Convergence diagnostics distribution plot
+
+Plot the distribution of ESS and R-hat.
+
+---
+
+:::{seealso}
+API Documentation: {func}`~arviz_plots.plot_ess`
+:::
+"""
+
+from arviz_base import load_arviz_data
+
+import arviz_plots as azp
+
+azp.style.use("arviz-clean")
+
+data = load_arviz_data("radon")
+pc = azp.plot_ess(
+    data,
+    var_names=["za_county"],
+    backend="none",  # change to preferred backend
+)
+pc.show()

--- a/docs/source/gallery/inference_diagnostics/plot_convergence_dist.py
+++ b/docs/source/gallery/inference_diagnostics/plot_convergence_dist.py
@@ -17,9 +17,9 @@ import arviz_plots as azp
 azp.style.use("arviz-clean")
 
 data = load_arviz_data("radon")
-pc = azp.plot_ess(
-    data,
-    var_names=["za_county"],
-    backend="none",  # change to preferred backend
+pc = azp.plot_convergence_dist(data,
+                               var_names=["za_county"],
+                               backend="none",  # change to preferred backend
 )
+
 pc.show()

--- a/docs/source/gallery/inference_diagnostics/plot_energy.py
+++ b/docs/source/gallery/inference_diagnostics/plot_energy.py
@@ -6,7 +6,7 @@ Plot transition and marginal energy distributions
 ---
 
 :::{seealso}
-API Documentation: {func}`~arviz_plots.plot_trace`
+API Documentation: {func}`~arviz_plots.plot_energy`
 :::
 """
 from arviz_base import load_arviz_data

--- a/src/arviz_plots/backend/bokeh/__init__.py
+++ b/src/arviz_plots/backend/bokeh/__init__.py
@@ -4,7 +4,7 @@ import warnings
 
 import numpy as np
 from bokeh.layouts import GridBox, gridplot
-from bokeh.models import GridPlot, Range1d, Title
+from bokeh.models import GridPlot, Range1d, Span, Title
 from bokeh.plotting import figure
 from bokeh.plotting import show as _show
 
@@ -363,6 +363,22 @@ def fill_between_y(x, y_bottom, y_top, target, **artist_kws):
     if y_top.size == 1:
         y_top = y_top.item()
     return target.varea(x=x, y1=y_bottom, y2=y_top, **artist_kws)
+
+
+def vline(x, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
+    """Interface to bokeh for a vertical line spanning the whole axes."""
+    kwargs = {"line_color": color, "line_alpha": alpha, "line_width": width, "line_dash": linestyle}
+    span_element = Span(location=x, dimension="height", **_filter_kwargs(kwargs, artist_kws))
+    target.add_layout(span_element)
+    return span_element
+
+
+def hline(y, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
+    """Interface to bokeh for a horizontal line spanning the whole axes."""
+    kwargs = {"line_color": color, "line_alpha": alpha, "line_width": width, "line_dash": linestyle}
+    span_element = Span(location=y, dimension="width", **_filter_kwargs(kwargs, artist_kws))
+    target.add_layout(span_element)
+    return span_element
 
 
 # general plot appeareance

--- a/src/arviz_plots/backend/matplotlib/__init__.py
+++ b/src/arviz_plots/backend/matplotlib/__init__.py
@@ -305,6 +305,20 @@ def fill_between_y(x, y_bottom, y_top, target, **artist_kws):
     return target.fill_between(x, y_bottom, y_top, **artist_kws)
 
 
+def vline(x, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
+    """Interface to matplotlib for a vertical line spanning the whole axes."""
+    artist_kws.setdefault("zorder", 2)
+    kwargs = {"color": color, "alpha": alpha, "linewidth": width, "linestyle": linestyle}
+    return target.axvline(x, **_filter_kwargs(kwargs, Line2D, artist_kws))
+
+
+def hline(y, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
+    """Interface to matplotlib for a horizontal line spanning the whole axes."""
+    artist_kws.setdefault("zorder", 2)
+    kwargs = {"color": color, "alpha": alpha, "linewidth": width, "linestyle": linestyle}
+    return target.axhline(y, **_filter_kwargs(kwargs, Line2D, artist_kws))
+
+
 # general plot appeareance
 def title(string, target, *, size=unset, color=unset, **artist_kws):
     """Interface to matplotlib for adding a title to a plot."""

--- a/src/arviz_plots/backend/none/__init__.py
+++ b/src/arviz_plots/backend/none/__init__.py
@@ -329,6 +329,34 @@ def fill_between_y(x, y_bottom, y_top, target, *, color=unset, alpha=unset, **ar
     return artist_element
 
 
+def vline(x, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
+    """Interface to a vertical line spanning the whole axes."""
+    kwargs = {"color": color, "alpha": alpha, "width": width, "linestyle": linestyle}
+    if not ALLOW_KWARGS and artist_kws:
+        raise ValueError("artist_kws not empty")
+    artist_element = {
+        "function": "vline",
+        "x": x,
+        **_filter_kwargs(kwargs, artist_kws),
+    }
+    target.append(artist_element)
+    return artist_element
+
+
+def hline(y, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
+    """Interface to a horizontal line spanning the whole axes."""
+    kwargs = {"color": color, "alpha": alpha, "width": width, "linestyle": linestyle}
+    if not ALLOW_KWARGS and artist_kws:
+        raise ValueError("artist_kws not empty")
+    artist_element = {
+        "function": "vline",
+        "y": y,
+        **_filter_kwargs(kwargs, artist_kws),
+    }
+    target.append(artist_element)
+    return artist_element
+
+
 # general plot appeareance
 def title(string, target, *, size=unset, color=unset, **artist_kws):
     """Interface to adding a title to a plot."""

--- a/src/arviz_plots/backend/plotly/__init__.py
+++ b/src/arviz_plots/backend/plotly/__init__.py
@@ -439,6 +439,28 @@ def fill_between_y(x, y_bottom, y_top, target, *, color=unset, alpha=unset, **ar
     return second_line_with_fill
 
 
+def vline(x, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
+    """Interface to plotly for a vertical line spanning the whole axes."""
+    artist_kws.setdefault("showlegend", False)
+    line_kwargs = {"color": color, "width": width, "dash": linestyle}
+    line_artist_kws = artist_kws.pop("line", {}).copy()
+    kwargs = {"opacity": alpha}
+    return target.add_vline(
+        x, line=_filter_kwargs(line_kwargs, line_artist_kws), **_filter_kwargs(kwargs, artist_kws)
+    )
+
+
+def hline(y, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
+    """Interface to plotly for a horizontal line spanning the whole axes."""
+    artist_kws.setdefault("showlegend", False)
+    line_kwargs = {"color": color, "width": width, "dash": linestyle}
+    line_artist_kws = artist_kws.pop("line", {}).copy()
+    kwargs = {"opacity": alpha}
+    return target.add_hline(
+        y, line=_filter_kwargs(line_kwargs, line_artist_kws), **_filter_kwargs(kwargs, artist_kws)
+    )
+
+
 # general plot appeareance
 def title(string, target, *, size=unset, color=unset, **artist_kws):
     """Interface to plotly for adding a title to a plot."""

--- a/src/arviz_plots/plots/__init__.py
+++ b/src/arviz_plots/plots/__init__.py
@@ -1,12 +1,12 @@
 """Batteries-included ArviZ plots."""
 
 from .compareplot import plot_compare
+from .convergencedistplot import plot_convergence_dist
 from .distplot import plot_dist
 from .energyplot import plot_energy
 from .essplot import plot_ess
 from .evolutionplot import plot_ess_evolution
 from .forestplot import plot_forest
-from .noseplot import plot_nose
 from .psensedistplot import plot_psense_dist
 from .ridgeplot import plot_ridge
 from .tracedistplot import plot_trace_dist
@@ -14,6 +14,7 @@ from .traceplot import plot_trace
 
 __all__ = [
     "plot_compare",
+    "plot_convergence_dist",
     "plot_dist",
     "plot_forest",
     "plot_trace",
@@ -23,5 +24,4 @@ __all__ = [
     "plot_ess_evolution",
     "plot_ridge",
     "plot_psense_dist",
-    "plot_nose",
 ]

--- a/src/arviz_plots/plots/__init__.py
+++ b/src/arviz_plots/plots/__init__.py
@@ -6,6 +6,7 @@ from .energyplot import plot_energy
 from .essplot import plot_ess
 from .evolutionplot import plot_ess_evolution
 from .forestplot import plot_forest
+from .noseplot import plot_nose
 from .psensedistplot import plot_psense_dist
 from .ridgeplot import plot_ridge
 from .tracedistplot import plot_trace_dist
@@ -22,4 +23,5 @@ __all__ = [
     "plot_ess_evolution",
     "plot_ridge",
     "plot_psense_dist",
+    "plot_nose",
 ]

--- a/src/arviz_plots/plots/convergencedistplot.py
+++ b/src/arviz_plots/plots/convergencedistplot.py
@@ -1,10 +1,15 @@
 """Convergence diagnostic distribution plot code."""
 import warnings
+from copy import copy
+from importlib import import_module
 
-from arviz_base import convert_to_dataset, rcParams
+import arviz_stats  # pylint: disable=unused-import
+import xarray as xr
+from arviz_base import rcParams
 
 from arviz_plots.plots.distplot import plot_dist
-from arviz_plots.plots.utils import process_group_variables_coords
+from arviz_plots.plots.utils import filter_aes, process_group_variables_coords
+from arviz_plots.visuals import vline
 
 
 def plot_convergence_dist(
@@ -34,14 +39,13 @@ def plot_convergence_dist(
     ----------
     dt : DataTree
         Input data
-    diagnostics : list of str
-        List of diagnostics to plot. Defaults to ["ess_bulk", "ess_tail", "rhat"].
-        Valid diagnostics are "rhat", "rhat_folded", "rhat_z_scale", "rhat_split",
+    diagnostics : list of str, optional
+        List of diagnostics to plot. Defaults to ["ess_bulk", "ess_tail", "rhat_rank"].
+        Valid diagnostics are "rhat_rank", "rhat_folded", "rhat_z_scale", "rhat_split",
         "rhat_identity", "ess_bulk", "ess_tail", "ess_mean", "ess_sd", "ess_quantile",
         "ess_local", "ess_median", "ess_mad", "ess_z_scale", "ess_folded" and "ess_identity".
-    ref_line : bool
+    ref_line : bool, default True
         Whether to plot a reference line for the recommended value of each diagnostic.
-        Defaults to True.
     var_names : str or list of str, optional
         One or more variables to be plotted.
         Prefix the variables by ~ when you want to exclude them from the plot.
@@ -49,6 +53,8 @@ def plot_convergence_dist(
         If None (default), interpret var_names as the real variables names.
         If “like”, interpret var_names as substrings of the real variables names.
         If “regex”, interpret var_names as regular expressions on the real variables names.
+    group : str, default "posterior"
+        The group for which to compute the convergence diagnostics.
     sample_dims : str or sequence of hashable, optional
         Dimensions to reduce unless mapped to an aesthetic.
         Defaults to ``rcParams["data.sample_dims"]``
@@ -60,57 +66,51 @@ def plot_convergence_dist(
     aes_map : mapping of {str : sequence of str}, optional
         Mapping of artists to aesthetics that should use their mapping in `plot_collection`
         when plotted. Valid keys are the same as for `plot_kwargs`.
-
+        By default, no mappings are defined for this plot.
     plot_kwargs : mapping of {str : mapping or False}, optional
         Valid keys are:
-
         * One of "kde", "ecdf", "dot" or "hist", matching the `kind` argument.
-
           * "kde" -> passed to :func:`~arviz_plots.visuals.line_xy`
           * "ecdf" -> passed to :func:`~arviz_plots.visuals.ecdf_line`
           * "hist" -> passed to :func: `~arviz_plots.visuals.hist`
-          * "ref_line" -> passed to :func:`~arviz_plots.visuals.axvline`
-
+        * ref_line -> passed to :func:`~arviz_plots.visuals.vline`
         * title -> passed to :func:`~arviz_plots.visuals.labelled_title`
         * remove_axis -> not passed anywhere, can only be ``False`` to skip calling this function
-
     stats_kwargs : mapping, optional
         Valid keys are:
         * density -> passed to kde, ecdf, ...
-
     pc_kwargs : mapping
         Passed to :class:`arviz_plots.PlotCollection.wrap`
-
     Returns
     -------
     PlotCollection
-
     Examples
     --------
     Select a single variable and specify diagnostics
-
     .. plot::
         :context: close-figs
-
         >>> from arviz_plots import plot_convergence_dist, style
         >>> style.use("arviz-clean")
         >>> from arviz_base import load_arviz_data
-        >>> rugby = load_arviz_data('radon')
-        >>> plot_convergence_dist(radon, var_names=["za_county"], diagnostics=["rhat", "ess_tail"])
-
-     Some ess methods accepts a probability argument
-
+        >>> radon = load_arviz_data('radon')
+        >>> plot_convergence_dist(
+        >>>     radon,
+        >>>     var_names=["za_county"],
+        >>>     diagnostics=["rhat", "ess_tail"]
+        >>> )
+    Some ess methods accepts a probability argument
     .. plot::
         :context: close-figs
-
-        >>> plot_convergence_dist(radon, var_names=["za_county"],
-                     diagnostics=["ess_tail(0.1, 0.9)",
-                                  "ess_local(0.1, 0.9)",
-                                  "ess_quantile(0.9)"])
-
-
+        >>> plot_convergence_dist(
+        >>>     radon,
+        >>>     var_names=["za_county"],
+        >>>     diagnostics=[
+        >>>         "ess_tail(0.1, 0.9)",
+        >>>         "ess_local(0.1, 0.9)",
+        >>>         "ess_quantile(0.9)"
+        >>>     ]
+        >>> )
     .. minigallery:: plot_convergence_dist
-
     """
     if sample_dims is None:
         sample_dims = rcParams["data.sample_dims"]
@@ -121,31 +121,54 @@ def plot_convergence_dist(
         plot_kwargs = {}
     else:
         plot_kwargs = plot_kwargs.copy()
+
+    ref_line_kwargs = copy(plot_kwargs.get("ref_line", {}))
+    if ref_line_kwargs is False:
+        raise ValueError(
+            "plot_kwargs['ref_line'] can't be False, use ref_line=False to remove this element"
+        )
+
     if pc_kwargs is None:
         pc_kwargs = {}
     else:
         pc_kwargs = pc_kwargs.copy()
 
+    if aes_map is None:
+        aes_map = {}
+    else:
+        aes_map = aes_map.copy()
+
     if diagnostics is None:
         diagnostics = ["ess_bulk", "ess_tail", "rhat"]
+    elif isinstance(diagnostics, str):
+        diagnostics = [diagnostics]
+
+    if backend is None:
+        if plot_collection is None:
+            backend = rcParams["plot.backend"]
+        else:
+            backend = plot_collection.backend
+    plot_bknd = import_module(f".backend.{backend}", package="arviz_plots")
 
     dt = process_group_variables_coords(
         dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords
     )
 
-    new_ds = _get_diagnostics(dt, diagnostics)
+    distribution = _compute_diagnostics(dt, diagnostics, sample_dims)
 
     plot_kwargs.setdefault("credible_interval", False)
     plot_kwargs.setdefault("point_estimate", False)
     plot_kwargs.setdefault("point_estimate_text", False)
 
     plot_collection = plot_dist(
-        new_ds,
+        distribution,
         var_names=None,
         filter_vars=None,
         group=None,
         coords=None,
-        sample_dims=sample_dims,
+        # _compute_diagnostics returns output with only this dimension
+        # it is the one we want reduced in plot_dist to show the distributions
+        sample_dims=["label"],
         kind=kind,
         point_estimate=point_estimate,
         ci_kind=ci_kind,
@@ -160,28 +183,32 @@ def plot_convergence_dist(
     )
 
     if ref_line:
-        plot_kwargs.setdefault("ref_line", {})
-        if plot_kwargs["ref_line"] is not False:
-            plot_kwargs["ref_line"].setdefault("color", "k")
-            plot_kwargs["ref_line"].setdefault("linestyle", "--")
-            plot_kwargs["ref_line"].setdefault("alpha", 0.5)
+        _, ref_aes, ref_ignore = filter_aes(plot_collection, aes_map, "ref_line", sample_dims)
+        if "color" not in ref_aes:
+            ref_line_kwargs.setdefault("color", "black")
+        if "linestyle" not in ref_aes:
+            default_linestyle = plot_bknd.get_default_aes("linestyle", 2, {})[1]
+            ref_line_kwargs.setdefault("linestyle", default_linestyle)
+        if "alpha" not in ref_aes:
+            ref_line_kwargs.setdefault("alpha", 0.5)
 
         ess_ref = dt.sizes["chain"] * 100
         # is this valid for all r_hat methods? Do we want to correct for multiple comparisons?
         r_hat_ref = 1.01
-        for diagnostic in diagnostics:
-            if "ess" in diagnostic:
-                ref = ess_ref
-            if "rhat" in diagnostic:
-                ref = r_hat_ref
-            plot_collection.viz[diagnostic]["plot"].item().axvline(
-                ref, color="k", linestyle="--", alpha=0.5
-            )
+        ref_ds = xr.Dataset(
+            {
+                diagnostic: ess_ref if "ess" in diagnostic else r_hat_ref
+                for diagnostic in distribution.data_vars
+            }
+        )
+        plot_collection.map(
+            vline, "ref_line", data=ref_ds, ignore_aes=ref_ignore, **ref_line_kwargs
+        )
 
     return plot_collection
 
 
-def _get_diagnostics(dt, diagnostics):
+def _compute_diagnostics(dt, diagnostics, sample_dims):
     diagnostic_values = {}
     for diagnostic in diagnostics:
         if "ess" in diagnostic:
@@ -189,17 +216,17 @@ def _get_diagnostics(dt, diagnostics):
             method = diagnostic.split("_", 1)[1].split("(", 1)[0]
             if method in {"tail", "quantile", "local"} and "(" in diagnostic:
                 prob = [float(p) for p in diagnostic.split("(", 1)[1].rstrip(")").split(", ")]
-            diagnostic_values[diagnostic] = (
-                dt.azstats.ess(method=method, prob=prob).to_array().values.reshape(1, -1)
-            )
+            diagnostic_values[diagnostic] = dt.azstats.ess(
+                method=method, prob=prob, dims=sample_dims
+            ).to_stacked_array("label", sample_dims=[])
         elif "rhat" in diagnostic:
-            if diagnostic == "rhat":
-                method = "rank"
-            else:
+            kwargs = {"dims": sample_dims}
+            if diagnostic != "rhat":
                 method = diagnostic.split("_", 1)[1]
-            diagnostic_values[diagnostic] = (
-                dt.azstats.rhat(method=method).to_array().values.reshape(1, -1)
+                kwargs.update({"method": method})
+            diagnostic_values[diagnostic] = dt.azstats.rhat(**kwargs).to_stacked_array(
+                "label", sample_dims=[]
             )
         else:
             warnings.warn(f"{diagnostic} is not recognized as a valid diagnostic")
-    return convert_to_dataset(diagnostic_values)
+    return xr.Dataset(diagnostic_values)

--- a/src/arviz_plots/plots/convergencedistplot.py
+++ b/src/arviz_plots/plots/convergencedistplot.py
@@ -1,4 +1,4 @@
-"""Nose plot code."""
+"""Convergence diagnostic distribution plot code."""
 import warnings
 
 from arviz_base import convert_to_dataset, rcParams
@@ -7,7 +7,7 @@ from arviz_plots.plots.distplot import plot_dist
 from arviz_plots.plots.utils import process_group_variables_coords
 
 
-def plot_nose(
+def plot_convergence_dist(
     dt,
     diagnostics=None,
     ref_line=True,
@@ -28,7 +28,7 @@ def plot_nose(
     stats_kwargs=None,
     pc_kwargs=None,
 ):
-    """Plot the distribution of ESS and R-hat.
+    """Plot the distribution of convergence diagnostics (ESS and/or R-hat).
 
     Parameters
     ----------
@@ -92,24 +92,24 @@ def plot_nose(
     .. plot::
         :context: close-figs
 
-        >>> from arviz_plots import plot_nose, style
+        >>> from arviz_plots import plot_convergence_dist, style
         >>> style.use("arviz-clean")
         >>> from arviz_base import load_arviz_data
         >>> rugby = load_arviz_data('radon')
-        >>> plot_nose(radon, var_names=["za_county"], diagnostics=["rhat", "ess_tail"])
+        >>> plot_convergence_dist(radon, var_names=["za_county"], diagnostics=["rhat", "ess_tail"])
 
      Some ess methods accepts a probability argument
 
     .. plot::
         :context: close-figs
 
-        >>> plot_nose(radon, var_names=["za_county"],
+        >>> plot_convergence_dist(radon, var_names=["za_county"],
                      diagnostics=["ess_tail(0.1, 0.9)",
                                   "ess_local(0.1, 0.9)",
                                   "ess_quantile(0.9)"])
 
 
-    .. minigallery:: plot_nose
+    .. minigallery:: plot_convergence_dist
 
     """
     if sample_dims is None:

--- a/src/arviz_plots/plots/convergencedistplot.py
+++ b/src/arviz_plots/plots/convergencedistplot.py
@@ -49,11 +49,13 @@ def plot_convergence_dist(
     var_names : str or list of str, optional
         One or more variables to be plotted.
         Prefix the variables by ~ when you want to exclude them from the plot.
-    filter_vars : {None, “like”, “regex”}, optional, default=None
-        If None (default), interpret var_names as the real variables names.
+    filter_vars : {None, “like”, “regex”}, default=None
+        If None, interpret var_names as the real variables names.
         If “like”, interpret var_names as substrings of the real variables names.
         If “regex”, interpret var_names as regular expressions on the real variables names.
     group : str, default "posterior"
+        Group to be plotted.
+    coords : dict, optional
         The group for which to compute the convergence diagnostics.
     sample_dims : str or sequence of hashable, optional
         Dimensions to reduce unless mapped to an aesthetic.
@@ -69,16 +71,22 @@ def plot_convergence_dist(
         By default, no mappings are defined for this plot.
     plot_kwargs : mapping of {str : mapping or False}, optional
         Valid keys are:
+
         * One of "kde", "ecdf", "dot" or "hist", matching the `kind` argument.
+
           * "kde" -> passed to :func:`~arviz_plots.visuals.line_xy`
           * "ecdf" -> passed to :func:`~arviz_plots.visuals.ecdf_line`
           * "hist" -> passed to :func: `~arviz_plots.visuals.hist`
+
         * ref_line -> passed to :func:`~arviz_plots.visuals.vline`
         * title -> passed to :func:`~arviz_plots.visuals.labelled_title`
         * remove_axis -> not passed anywhere, can only be ``False`` to skip calling this function
+
     stats_kwargs : mapping, optional
         Valid keys are:
+
         * density -> passed to kde, ecdf, ...
+
     pc_kwargs : mapping
         Passed to :class:`arviz_plots.PlotCollection.wrap`
 
@@ -107,6 +115,7 @@ def plot_convergence_dist(
 
     .. plot::
         :context: close-figs
+
         >>> plot_convergence_dist(
         >>>     radon,
         >>>     var_names=["za_county"],

--- a/src/arviz_plots/plots/convergencedistplot.py
+++ b/src/arviz_plots/plots/convergencedistplot.py
@@ -81,14 +81,18 @@ def plot_convergence_dist(
         * density -> passed to kde, ecdf, ...
     pc_kwargs : mapping
         Passed to :class:`arviz_plots.PlotCollection.wrap`
+
     Returns
     -------
     PlotCollection
+
     Examples
     --------
     Select a single variable and specify diagnostics
+
     .. plot::
         :context: close-figs
+
         >>> from arviz_plots import plot_convergence_dist, style
         >>> style.use("arviz-clean")
         >>> from arviz_base import load_arviz_data
@@ -98,7 +102,9 @@ def plot_convergence_dist(
         >>>     var_names=["za_county"],
         >>>     diagnostics=["rhat", "ess_tail"]
         >>> )
+
     Some ess methods accepts a probability argument
+
     .. plot::
         :context: close-figs
         >>> plot_convergence_dist(
@@ -110,7 +116,9 @@ def plot_convergence_dist(
         >>>         "ess_quantile(0.9)"
         >>>     ]
         >>> )
+
     .. minigallery:: plot_convergence_dist
+
     """
     if sample_dims is None:
         sample_dims = rcParams["data.sample_dims"]

--- a/src/arviz_plots/plots/convergencedistplot.py
+++ b/src/arviz_plots/plots/convergencedistplot.py
@@ -35,8 +35,8 @@ def plot_convergence_dist(
     dt : DataTree
         Input data
     diagnostics : list of str
-        List of diagnostics to plot. Defaults to ["ess_bulk", "ess_tail", "rhat_rank"].
-        Valid diagnostics are "rhat_rank", "rhat_folded", "rhat_z_scale", "rhat_split",
+        List of diagnostics to plot. Defaults to ["ess_bulk", "ess_tail", "rhat"].
+        Valid diagnostics are "rhat", "rhat_folded", "rhat_z_scale", "rhat_split",
         "rhat_identity", "ess_bulk", "ess_tail", "ess_mean", "ess_sd", "ess_quantile",
         "ess_local", "ess_median", "ess_mad", "ess_z_scale", "ess_folded" and "ess_identity".
     ref_line : bool
@@ -127,7 +127,7 @@ def plot_convergence_dist(
         pc_kwargs = pc_kwargs.copy()
 
     if diagnostics is None:
-        diagnostics = ["ess_bulk", "ess_tail", "rhat_rank"]
+        diagnostics = ["ess_bulk", "ess_tail", "rhat"]
 
     dt = process_group_variables_coords(
         dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords
@@ -193,7 +193,10 @@ def _get_diagnostics(dt, diagnostics):
                 dt.azstats.ess(method=method, prob=prob).to_array().values.reshape(1, -1)
             )
         elif "rhat" in diagnostic:
-            method = diagnostic.split("_", 1)[1]
+            if diagnostic == "rhat":
+                method = "rank"
+            else:
+                method = diagnostic.split("_", 1)[1]
             diagnostic_values[diagnostic] = (
                 dt.azstats.rhat(method=method).to_array().values.reshape(1, -1)
             )

--- a/src/arviz_plots/plots/noseplot.py
+++ b/src/arviz_plots/plots/noseplot.py
@@ -1,0 +1,175 @@
+"""Nose plot code."""
+import warnings
+
+from arviz_base import convert_to_dataset, rcParams
+
+from arviz_plots.plots.distplot import plot_dist
+from arviz_plots.plots.utils import process_group_variables_coords
+
+
+def plot_nose(
+    dt,
+    diagnostics=None,
+    var_names=None,
+    filter_vars=None,
+    group="posterior",
+    coords=None,
+    sample_dims=None,
+    kind="ecdf",
+    point_estimate=None,
+    ci_kind=None,
+    ci_prob=None,
+    plot_collection=None,
+    backend=None,
+    labeller=None,
+    aes_map=None,
+    plot_kwargs=None,
+    stats_kwargs=None,
+    pc_kwargs=None,
+):
+    """Plot the distribution of ESS and R-hat.
+
+    Parameters
+    ----------
+    dt : DataTree
+        Input data
+    diagnostics : list of str
+        List of diagnostics to plot. Defaults to ["ess_bulk", "ess_tail", "rhat"].
+        Valid diagnostics are "rhat", "ess_bulk", "ess_tail",
+        "ess_mean", "ess_sd", "ess_quantile", "ess_local", "ess_median", "ess_mad",
+        "ess_z_scale", "ess_folded" and "ess_identity".
+    var_names : str or list of str, optional
+        One or more variables to be plotted.
+        Prefix the variables by ~ when you want to exclude them from the plot.
+    filter_vars : {None, “like”, “regex”}, optional, default=None
+        If None (default), interpret var_names as the real variables names.
+        If “like”, interpret var_names as substrings of the real variables names.
+        If “regex”, interpret var_names as regular expressions on the real variables names.
+    sample_dims : str or sequence of hashable, optional
+        Dimensions to reduce unless mapped to an aesthetic.
+        Defaults to ``rcParams["data.sample_dims"]``
+    kind : {"kde", "hist", "dot", "ecdf"}, optional
+        How to represent the distribution of diagnostics. Default to ecdf
+    plot_collection : PlotCollection, optional
+    backend : {"matplotlib", "bokeh", "plotly"}, optional
+    labeller : labeller, optional
+    aes_map : mapping of {str : sequence of str}, optional
+        Mapping of artists to aesthetics that should use their mapping in `plot_collection`
+        when plotted. Valid keys are the same as for `plot_kwargs`.
+
+    plot_kwargs : mapping of {str : mapping or False}, optional
+        Valid keys are:
+
+        * One of "kde", "ecdf", "dot" or "hist", matching the `kind` argument.
+
+          * "kde" -> passed to :func:`~arviz_plots.visuals.line_xy`
+          * "ecdf" -> passed to :func:`~arviz_plots.visuals.ecdf_line`
+          * "hist" -> passed to :func: `~arviz_plots.visuals.hist`
+
+        * title -> passed to :func:`~arviz_plots.visuals.labelled_title`
+        * remove_axis -> not passed anywhere, can only be ``False`` to skip calling this function
+
+    stats_kwargs : mapping, optional
+        Valid keys are:
+        * density -> passed to kde, ecdf, ...
+
+    pc_kwargs : mapping
+        Passed to :class:`arviz_plots.PlotCollection.wrap`
+
+    Returns
+    -------
+    PlotCollection
+
+    Examples
+    --------
+    Select a single variable and specify diagnostics
+
+    .. plot::
+        :context: close-figs
+
+        >>> from arviz_plots import plot_nose, style
+        >>> style.use("arviz-clean")
+        >>> from arviz_base import load_arviz_data
+        >>> rugby = load_arviz_data('radon')
+        >>> plot_nose(radon, var_names=["za_county"], diagnostics=["rhat", "ess_tail"])
+
+     Some ess methods accepts a probability argument
+
+    .. plot::
+        :context: close-figs
+
+        >>> plot_nose(radon, var_names=["za_county"],
+                     diagnostics=["ess_tail(0.1, 0.9)",
+                                  "ess_local(0.1, 0.9)",
+                                  "ess_quantile(0.9)"])
+
+
+    .. minigallery:: plot_nose
+
+    """
+    if sample_dims is None:
+        sample_dims = rcParams["data.sample_dims"]
+    if isinstance(sample_dims, str):
+        sample_dims = [sample_dims]
+    sample_dims = list(sample_dims)
+    if plot_kwargs is None:
+        plot_kwargs = {}
+    else:
+        plot_kwargs = plot_kwargs.copy()
+    if pc_kwargs is None:
+        pc_kwargs = {}
+    else:
+        pc_kwargs = pc_kwargs.copy()
+
+    if diagnostics is None:
+        diagnostics = ["ess_bulk", "ess_tail", "rhat"]
+
+    dt = process_group_variables_coords(
+        dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords
+    )
+
+    new_ds = _get_diagnostics(dt, diagnostics)
+
+    plot_kwargs.setdefault("credible_interval", False)
+    plot_kwargs.setdefault("point_estimate", False)
+    plot_kwargs.setdefault("point_estimate_text", False)
+
+    plot_collection = plot_dist(
+        new_ds,
+        var_names=None,
+        filter_vars=None,
+        group=None,
+        coords=None,
+        sample_dims=sample_dims,
+        kind=kind,
+        point_estimate=point_estimate,
+        ci_kind=ci_kind,
+        ci_prob=ci_prob,
+        plot_collection=plot_collection,
+        backend=backend,
+        labeller=labeller,
+        aes_map=aes_map,
+        plot_kwargs=plot_kwargs,
+        stats_kwargs=stats_kwargs,
+        pc_kwargs=pc_kwargs,
+    )
+
+    return plot_collection
+
+
+def _get_diagnostics(dt, diagnostics):
+    diagnostic_values = {}
+    for diagnostic in diagnostics:
+        if "ess" in diagnostic:
+            prob = None
+            method = diagnostic.split("_", 1)[1].split("(", 1)[0]
+            if method in {"tail", "quantile", "local"} and "(" in diagnostic:
+                prob = [float(p) for p in diagnostic.split("(", 1)[1].rstrip(")").split(", ")]
+            diagnostic_values[diagnostic] = (
+                dt.azstats.ess(method=method, prob=prob).to_array().values.reshape(1, -1)
+            )
+        elif "rhat" in diagnostic:
+            diagnostic_values[diagnostic] = dt.azstats.rhat().to_array().values.reshape(1, -1)
+        else:
+            warnings.warn(f"{diagnostic} is not recognized as a valid diagnostic")
+    return convert_to_dataset(diagnostic_values)

--- a/src/arviz_plots/plots/noseplot.py
+++ b/src/arviz_plots/plots/noseplot.py
@@ -35,7 +35,7 @@ def plot_nose(
     dt : DataTree
         Input data
     diagnostics : list of str
-        List of diagnostics to plot. Defaults to ["ess_bulk", "ess_tail", "rhat"].
+        List of diagnostics to plot. Defaults to ["ess_bulk", "ess_tail", "rhat_rank"].
         Valid diagnostics are "rhat_rank", "rhat_folded", "rhat_z_scale", "rhat_split",
         "rhat_identity", "ess_bulk", "ess_tail", "ess_mean", "ess_sd", "ess_quantile",
         "ess_local", "ess_median", "ess_mad", "ess_z_scale", "ess_folded" and "ess_identity".

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -107,6 +107,18 @@ def ecdf_line(values, target, backend, **kwargs):
     return plot_backend.line(values.sel(plot_axis="x"), values.sel(plot_axis="y"), target, **kwargs)
 
 
+def vline(values, target, backend, **kwargs):
+    """Plot a vertical line that spans the whole figure independently of zoom."""
+    plot_backend = import_module(f"arviz_plots.backend.{backend}")
+    return plot_backend.vline(values.item(), target, **kwargs)
+
+
+def hline(values, target, backend, **kwargs):
+    """Plot a horizontal line that spans the whole figure independently of zoom."""
+    plot_backend = import_module(f"arviz_plots.backend.{backend}")
+    return plot_backend.hline(values.item(), target, **kwargs)
+
+
 def fill_between_y(da, target, backend, *, x=None, y_bottom=None, y=None, y_top=None, **kwargs):
     """Fill the region between to given y values."""
     if "kwarg" in da.dims:

--- a/tests/test_hypothesis_plots.py
+++ b/tests/test_hypothesis_plots.py
@@ -371,8 +371,9 @@ def test_plot_psense(datatree, alphas, kind, point_estimate, ci_kind, plot_kwarg
         [
             # fmt: off
             None, "rhat", "rhat_rank", "rhat_folded", "rhat_z_scale", "rhat_split",
-            "rhat_identity", "ess_bulk", "ess_tail", "ess_mean", "ess_sd", "ess_quantile",
-            "ess_local", "ess_median", "ess_mad", "ess_z_scale", "ess_folded", "ess_identity"
+            "rhat_identity", "ess_bulk", "ess_tail", "ess_mean", "ess_sd",
+            "ess_quantile(0.9)", "ess_local(0.1, 0.9)", "ess_median", "ess_mad",
+            "ess_z_scale", "ess_folded", "ess_identity"
             # fmt: on
         ]
     ),


### PR DESCRIPTION
I don't have a good name for this plot so its code name is `plot_nose`. The motivation is to visually inspect the values of ESS and R-hat for many variables. 


In PyMC-BART we have a [plot_convergence](https://www.pymc.io/projects/bart/en/latest/examples/bart_introduction.html#convergence-diagnostics) function that generates a similar plot, which we used to check the "BART variables" which are always multidimensional with a size at least equal to the observations.  The interest is not on any individual variables. This type of plot may be of interest to others outside of PyMC-BART.

```python
azp.plot_convergence_dist(radon, var_names=["za_county"])
```

I feel tempted to call "rhat_rank" just "rhat". What do you think?

![nose_default](https://github.com/user-attachments/assets/62a19385-582e-489e-911c-9312fad9a730)




specific diagnostics can be passed as strings. 

```python
azp.plot_convergence_dist(radon, var_names=["za_county"], diagnostics=["ess_tail", "ess_median"])
```

![nose_method](https://github.com/user-attachments/assets/ff021590-a236-42ad-9bb7-8377b763dbbd)




some ess methods accept a prob argument, we can pass it also as part of the string, like a "tuple"

```python
azp.plot_convergence_dist(radon,
              var_names=["za_county"],
              diagnostics=["ess_tail(0.1, 0.9)", "ess_local(0.1, 0.9)", "ess_quantile(0.9)"],
              ref_line=False)
```

![nose_probs](https://github.com/user-attachments/assets/e5b199a5-bb75-4cb9-be2c-5334144e3b9b)


~We could also add reference lines for ESS and r-hat following standard recommendations~ (added). For PyMC-BART, we have an "inflated" R-hat reference value. We use a [heuristics](https://github.com/pymc-devs/pymc-bart/blob/main/pymc_bart/utils.py#L126C1-L128C84) to increase the 1.01 value based on the number of variables. Not saying we should use that heuristic, just saying we may want to have something similar.


<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--105.org.readthedocs.build/en/105/

<!-- readthedocs-preview arviz-plots end -->