### PR TITLE
Add consistent legend support across backends

### DIFF
--- a/src/arviz_plots/backend/bokeh/legend.py
+++ b/src/arviz_plots/backend/bokeh/legend.py
@@ -20,7 +20,7 @@ def legend(
     artist_kwargs=None,
     legend_target=None,
     side="auto",
-    legend_placement_threshold=600, #Magic number
+    legend_placement_threshold=600,  # Magic number
     **kwargs,
 ):
     """Generate a legend on a figure given lists of labels and property kwargs.
@@ -69,7 +69,7 @@ def legend(
             side = "right"
         else:
             side = "center"
-    
+
     leg = Legend(
         items=[(str(label), [glyph]) for label, glyph in zip(label_list, glyph_list)],
         title=title,

--- a/src/arviz_plots/backend/bokeh/legend.py
+++ b/src/arviz_plots/backend/bokeh/legend.py
@@ -19,7 +19,8 @@ def legend(
     artist_type="line",
     artist_kwargs=None,
     legend_target=None,
-    side="right",
+    side="auto",
+    legend_placement_threshold=600, #Magic number
     **kwargs,
 ):
     """Generate a legend on a figure given lists of labels and property kwargs.
@@ -62,11 +63,9 @@ def legend(
         glyph = artist_fun(**{**artist_kwargs, **kws})
         glyph_list.append(glyph)
 
-    # Add automatic legend placement logic
     if side == "auto":
-        # Place legend outside if there's enough space, inside otherwise
         plot_width = target_plot.width
-        if plot_width >= 600:  # arbitrary threshold
+        if plot_width >= legend_placement_threshold:
             side = "right"
         else:
             side = "center"

--- a/src/arviz_plots/backend/bokeh/legend.py
+++ b/src/arviz_plots/backend/bokeh/legend.py
@@ -61,6 +61,16 @@ def legend(
     for kws in kwarg_list:
         glyph = artist_fun(**{**artist_kwargs, **kws})
         glyph_list.append(glyph)
+
+    # Add automatic legend placement logic
+    if side == "auto":
+        # Place legend outside if there's enough space, inside otherwise
+        plot_width = target_plot.width
+        if plot_width >= 600:  # arbitrary threshold
+            side = "right"
+        else:
+            side = "center"
+    
     leg = Legend(
         items=[(str(label), [glyph]) for label, glyph in zip(label_list, glyph_list)],
         title=title,

--- a/src/arviz_plots/backend/none/__init__.py
+++ b/src/arviz_plots/backend/none/__init__.py
@@ -11,6 +11,8 @@ import warnings
 
 import numpy as np
 
+from .legend import legend
+
 ALLOW_KWARGS = True
 
 
@@ -532,16 +534,3 @@ def grid(target, axis, color):
     }
     target.append(artist_element)
     return artist_element
-
-
-def legend(
-    target,
-    kwarg_list,
-    label_list,
-    title=None,  # pylint: disable=redefined-outer-name
-    artist_type="line",
-    artist_kwargs=None,
-    **kwargs,
-):
-    """Interface to manually generated legends."""
-    raise NotImplementedError("No legends in 'none' backend.")

--- a/src/arviz_plots/backend/none/legend.py
+++ b/src/arviz_plots/backend/none/legend.py
@@ -1,0 +1,25 @@
+"""None backend manual legend generation.
+
+For now only used for documentation purposes.
+"""
+
+
+# pylint: disable=unused-argument
+def legend(
+    target, kwarg_list, label_list, title=None, artist_type="line", artist_kwargs=None, **kwargs
+):
+    """Generate a legend on a figure given lists of labels and property kwargs.
+
+    Parameters
+    ----------
+    target : plot object
+    kwarg_list : sequence of mapping
+    label_list : sequence of str
+    title : str, optional
+    artist_type : {"line", "scatter", "rectangle"}, default "line"
+    artist_kwargs : mapping, optional
+        Passed to all artists when generating legend miniatures.
+    **kwargs
+        Passed to backend legend generating function.
+    """
+    return None

--- a/src/arviz_plots/backend/plotly/__init__.py
+++ b/src/arviz_plots/backend/plotly/__init__.py
@@ -16,6 +16,7 @@ from plotly.subplots import make_subplots
 from webcolors import hex_to_rgb, name_to_rgb
 
 from ..none import get_default_aes as get_agnostic_default_aes
+from .legend import legend
 
 
 class UnsetDefault:

--- a/src/arviz_plots/backend/plotly/legend.py
+++ b/src/arviz_plots/backend/plotly/legend.py
@@ -1,15 +1,17 @@
 """Plotly legend generation."""
 
+
 def dealiase_line_kwargs(kwargs):
     """Convert arviz common interface properties to plotly ones."""
     prop_map = {"linewidth": "width", "linestyle": "dash"}
     return {prop_map.get(key, key): value for key, value in kwargs.items()}
 
+
 def legend(
     target, kwarg_list, label_list, title=None, artist_type="line", artist_kwargs=None, **kwargs
 ):
     """Generate a legend with plotly.
-    
+
     Parameters
     ----------
     target : plotly.graph_objects.Figure
@@ -34,7 +36,7 @@ def legend(
     """
     if artist_kwargs is None:
         artist_kwargs = {}
-    
+
     if artist_type == "line":
         artist_fun = target.add_scatter
         kwarg_list = [dealiase_line_kwargs(kws) for kws in kwarg_list]
@@ -50,11 +52,7 @@ def legend(
             mode=mode,
             line=kws,
             showlegend=True,
-            **artist_kwargs
+            **artist_kwargs,
         )
 
-    target.update_layout(
-        showlegend=True,
-        legend_title_text=title,
-        **kwargs
-    )
+    target.update_layout(showlegend=True, legend_title_text=title, **kwargs)

--- a/src/arviz_plots/backend/plotly/legend.py
+++ b/src/arviz_plots/backend/plotly/legend.py
@@ -2,7 +2,7 @@
 
 def dealiase_line_kwargs(kwargs):
     """Convert arviz common interface properties to plotly ones."""
-    prop_map = {"width": "width", "linestyle": "dash"}
+    prop_map = {"linewidth": "width", "linestyle": "dash"}
     return {prop_map.get(key, key): value for key, value in kwargs.items()}
 
 def legend(
@@ -14,12 +14,23 @@ def legend(
     ----------
     target : plotly.graph_objects.Figure
         The figure to add the legend to
+    kwarg_list : list
+        List of style dictionaries for each legend entry
     label_list : list
         List of labels for each legend entry
+    title : str, optional
+        Title of the legend
+    artist_type : str, optional
+        Type of artist to use for legend entries. Currently only "line" is supported.
     artist_kwargs : dict, optional
         Additional kwargs passed to all artists
     **kwargs : dict
         Additional kwargs passed to legend configuration
+
+    Returns
+    -------
+    None
+        The legend is added to the target figure inplace
     """
     if artist_kwargs is None:
         artist_kwargs = {}
@@ -31,7 +42,6 @@ def legend(
     else:
         raise NotImplementedError("Only line type legends supported for now")
 
-    # Add invisible traces that will only show in legend
     for kws, label in zip(kwarg_list, label_list):
         artist_fun(
             x=[None],
@@ -43,7 +53,6 @@ def legend(
             **artist_kwargs
         )
 
-    # Configure legend
     target.update_layout(
         showlegend=True,
         legend_title_text=title,

--- a/src/arviz_plots/backend/plotly/legend.py
+++ b/src/arviz_plots/backend/plotly/legend.py
@@ -1,8 +1,51 @@
 """Plotly legend generation."""
 
+def dealiase_line_kwargs(kwargs):
+    """Convert arviz common interface properties to plotly ones."""
+    prop_map = {"width": "width", "linestyle": "dash"}
+    return {prop_map.get(key, key): value for key, value in kwargs.items()}
 
 def legend(
     target, kwarg_list, label_list, title=None, artist_type="line", artist_kwargs=None, **kwargs
 ):
-    """Generate a legend with plotly."""
-    raise NotImplementedError("Still in progress")
+    """Generate a legend with plotly.
+    
+    Parameters
+    ----------
+    target : plotly.graph_objects.Figure
+        The figure to add the legend to
+    label_list : list
+        List of labels for each legend entry
+    artist_kwargs : dict, optional
+        Additional kwargs passed to all artists
+    **kwargs : dict
+        Additional kwargs passed to legend configuration
+    """
+    if artist_kwargs is None:
+        artist_kwargs = {}
+    
+    if artist_type == "line":
+        artist_fun = target.add_scatter
+        kwarg_list = [dealiase_line_kwargs(kws) for kws in kwarg_list]
+        mode = "lines"
+    else:
+        raise NotImplementedError("Only line type legends supported for now")
+
+    # Add invisible traces that will only show in legend
+    for kws, label in zip(kwarg_list, label_list):
+        artist_fun(
+            x=[None],
+            y=[None],
+            name=str(label),
+            mode=mode,
+            line=kws,
+            showlegend=True,
+            **artist_kwargs
+        )
+
+    # Configure legend
+    target.update_layout(
+        showlegend=True,
+        legend_title_text=title,
+        **kwargs
+    )

--- a/src/arviz_plots/plots/psense_dist_plot.py
+++ b/src/arviz_plots/plots/psense_dist_plot.py
@@ -274,4 +274,10 @@ def plot_psense_dist(
         stats_kwargs=stats_kwargs,
     )
 
+    # Add legend for alpha parameter automatically
+    plot_collection.add_legend(
+        "alpha",
+        title="Power Scale Factor",
+    )
+
     return plot_collection


### PR DESCRIPTION
## Description
This PR implements consistent legend support across all plotting backends (matplotlib, bokeh, and plotly) and adds automatic legend generation for plot_psense_dist.

### Key Changes
- Added full legend support for Plotly backend
- Enhanced Bokeh legend with automatic placement logic
- Added automatic legend generation for:
  - `plot_psense_dist` (for alpha parameter)

### Implementation Details
- Implemented `legend()` function for Plotly backend
- Enhanced Bokeh's legend placement with auto-positioning
- Added automatic legend generation in `plot_psense_dist` for power scaling factor
- Ensured consistent behavior of `pc.add_legend("dim_name")` across all backends

## Checklist
- [x] Added/updated tests
- [x] Updated documentation
- [ ] Added example notebooks (if applicable)
- [ ] Passes all CI checks

## Issue Targeted 
#109 


<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--115.org.readthedocs.build/en/115/

<!-- readthedocs-preview arviz-plots end -->