### PR TITLE
plotly: change format of title update in backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ funding = "https://opencollective.com/arviz"
 [project.optional-dependencies]
 matplotlib = ["matplotlib"]
 bokeh = ["bokeh"]
-plotly = ["plotly<6", "webcolors"]
+plotly = ["plotly>=6", "webcolors"]
 test = [
     "hypothesis",
     "pytest",

--- a/src/arviz_plots/backend/plotly/__init__.py
+++ b/src/arviz_plots/backend/plotly/__init__.py
@@ -486,7 +486,7 @@ def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
     """Interface to plotly for adding a label to the y axis."""
     kwargs = {"size": size, "color": color}
     target.update_yaxes(
-        title=str_to_plotly_html(string), titlefont=_filter_kwargs(kwargs, artist_kws)
+        title={"text": str_to_plotly_html(string), "font": _filter_kwargs(kwargs, artist_kws)}
     )
 
 
@@ -494,7 +494,7 @@ def xlabel(string, target, *, size=unset, color=unset, **artist_kws):
     """Interface to plotly for adding a label to the y axis."""
     kwargs = {"size": size, "color": color}
     target.update_xaxes(
-        title=str_to_plotly_html(string), titlefont=_filter_kwargs(kwargs, artist_kws)
+        title={"text": str_to_plotly_html(string), "font": _filter_kwargs(kwargs, artist_kws)}
     )
 
 


### PR DESCRIPTION
Closes #118 
There is a compatiblity issue with [plotly.graph_objects.layout.xaxis](https://plotly.com/python-api-reference/generated/plotly.graph_objects.layout.xaxis.html) package, because `titlefont` parameter has been removed and it triggers an error in plotly backend folder while updating labels.

## Changes 

Change format for `xlabel` & `ylabel` update

<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--124.org.readthedocs.build/en/124/

<!-- readthedocs-preview arviz-plots end -->