### PR TITLE
use <6 version of plotly for documentation and use latest for other purposes

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,4 +20,3 @@ python:
        - doc
        - matplotlib
        - bokeh
-       - plotly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ funding = "https://opencollective.com/arviz"
 [project.optional-dependencies]
 matplotlib = ["matplotlib"]
 bokeh = ["bokeh"]
-plotly = ["plotly<6", "webcolors"]
+plotly = ["plotly", "webcolors"]
 test = [
     "hypothesis",
     "pytest",
@@ -59,6 +59,7 @@ doc = [
     "sphinx-design",
     "jupyter-sphinx",
     "h5netcdf",
+    "plotly<6",
 ]
 
 


### PR DESCRIPTION
Fixes #129 temporarily.

Changes code so that: 
- Doc builds with plotly version < 6 
- Other functionalities work with current plotly version

Issue is because of latest update of plotly, due to which the default interactive renderer  ( ` plotly_mimetype+notebook` )  of figure.show() in plotly is not supporting anymore in sphinx. While renderers like `svg` , `png` etc. are still supported.

When the issue gets fixed in plotly, sphinx or other related packages, then we can comeback to resolve it.