### PR TITLE
added functionality of step histogram for all three backends

### DIFF
--- a/src/arviz_plots/backend/bokeh/__init__.py
+++ b/src/arviz_plots/backend/bokeh/__init__.py
@@ -275,14 +275,37 @@ def hist(
     facecolor=unset,
     edgecolor=unset,
     alpha=unset,
+    step_hist=False,
+    step_mode="center",
     **artist_kws,
 ):
-    """Interface to Bokeh for a histogram bar plot."""
+    """Interface to Bokeh for a histogram bar or step plot."""
     if color is not unset:
         if facecolor is unset:
             facecolor = color
         if edgecolor is unset:
             edgecolor = color
+
+    # Ensure alpha and colors have default values
+    alpha = 1.0 if alpha is unset else alpha
+    edgecolor = "black" if edgecolor is unset else edgecolor
+
+    if step_hist:
+        x = [l_e[0], l_e[0]]
+        y_step = [0, y[0]]
+        for i, y_i in enumerate(y):
+            x.append(r_e[i])
+            y_step.append(y_i)
+        x.append(r_e[-1])
+        y_step.append(bottom)
+
+        p = target.step(x, y_step, line_color=edgecolor, alpha=alpha, mode=step_mode, **artist_kws)
+
+        target.x_range = Range1d(float(l_e[0]), float(r_e[-1]))
+        target.y_range = Range1d(float(bottom), float(max(y)) * 1.2)  # Add padding to y-axis
+
+        return p
+
     kwargs = {"bottom": bottom, "fill_color": facecolor, "line_color": edgecolor, "alpha": alpha}
     return target.quad(top=y, left=l_e, right=r_e, **_filter_kwargs(kwargs, artist_kws))
 

--- a/src/arviz_plots/backend/matplotlib/__init__.py
+++ b/src/arviz_plots/backend/matplotlib/__init__.py
@@ -211,6 +211,7 @@ def hist(
     alpha=unset,
     facecolor=unset,
     edgecolor=unset,
+    step_hist=False,
     **artist_kws,
 ):
     """Interface to matplotlib for a histogram bar plot."""
@@ -225,9 +226,23 @@ def hist(
             facecolor = color
         if edgecolor is unset:
             edgecolor = color
-    kwargs = {"bottom": bottom, "color": facecolor, "edgecolor": edgecolor, "alpha": alpha}
+    kwargs = {"color": facecolor, "alpha": alpha}
+    if step_hist:
+        return target.step(
+            np.r_[l_e, r_e[-1]],
+            np.r_[y, y[-1]],
+            where="post",
+            **_filter_kwargs(kwargs, None, artist_kws),
+        )
+
     return target.bar(
-        l_e, height, width=widths, align="edge", **_filter_kwargs(kwargs, None, artist_kws)
+        l_e,
+        height,
+        width=widths,
+        align="edge",
+        bottom=bottom,
+        edgecolor=edgecolor,
+        **_filter_kwargs(kwargs, None, artist_kws),
     )
 
 

--- a/src/arviz_plots/backend/none/__init__.py
+++ b/src/arviz_plots/backend/none/__init__.py
@@ -191,7 +191,17 @@ def _filter_kwargs(kwargs, artist_kws):
 
 
 def hist(
-    y, l_e, r_e, target, *, bottom=None, color=unset, facecolor=unset, edgecolor=unset, **artist_kws
+    y,
+    l_e,
+    r_e,
+    target,
+    *,
+    bottom=None,
+    color=unset,
+    facecolor=unset,
+    edgecolor=unset,
+    step_hist="False",
+    **artist_kws,
 ):
     """Interface to matplotlib for a histogram bar plot."""
     if not ALLOW_KWARGS and artist_kws:

--- a/src/arviz_plots/plot_collection.py
+++ b/src/arviz_plots/plot_collection.py
@@ -935,6 +935,7 @@ class PlotCollection:
         subset_info=False,
         store_artist=True,
         artist_dims=None,
+        step_hist=False,
         **kwargs,
     ):
         """Apply the given plotting function to all plots with the corresponding aesthetics.
@@ -974,6 +975,10 @@ class PlotCollection:
         artist_dims : mapping of {hashable : int}, optional
             Dictionary of sizes for proper allocation and storage when using
             ``map`` with functions that return an array of :term:`artist`.
+        step_hist : boolean, default False
+            Flag to indicate that the `hist` function should be called with
+            the keyword argument `step_hist=True` if step histogram is required
+            instead of bar histogram.
         **kwargs : mapping, optional
             Keyword arguments passed as is to `fun`. Values within `**kwargs`
             with :class:`~xarray.DataArray` of :class:`~xarray.Dataset` type
@@ -1040,8 +1045,14 @@ class PlotCollection:
             fun_kwargs["backend"] = self.backend
             if subset_info:
                 fun_kwargs = {**fun_kwargs, "var_name": var_name, "sel": sel, "isel": isel}
-            aux_artist = fun(da, target=target, **fun_kwargs)
+
+            if step_hist:
+                aux_artist = fun(da, target=target, step_hist=True, **fun_kwargs)
+            else:
+                aux_artist = fun(da, target=target, **fun_kwargs)
             if store_artist:
+                if np.size(aux_artist) == 1:
+                    aux_artist = np.squeeze(aux_artist)
                 self.viz[var_name][fun_label].loc[sel] = aux_artist
 
     def add_legend(self, dim, var_name=None, aes=None, artist_kwargs=None, title=None, **kwargs):

--- a/src/arviz_plots/plots/distplot.py
+++ b/src/arviz_plots/plots/distplot.py
@@ -39,6 +39,7 @@ def plot_dist(
     aes_map=None,
     plot_kwargs=None,
     stats_kwargs=None,
+    step_hist=False,
     pc_kwargs=None,
 ):
     """Plot 1D marginal densities in the style of John K. Kruschke’s book.
@@ -113,6 +114,11 @@ def plot_dist(
         * density -> passed to kde, ecdf, ...
         * credible_interval -> passed to eti or hdi
         * point_estimate -> passed to mean, median or mode
+
+    step_hist : boolean, default False
+            Flag to indicate that the `hist` function should be called with
+            the keyword argument `step_hist=True` if step histogram is required
+            instead of bar histogram.
 
     pc_kwargs : mapping
         Passed to :class:`arviz_plots.PlotCollection.wrap`
@@ -281,7 +287,12 @@ def plot_dist(
             )
 
             plot_collection.map(
-                hist, "hist", data=density, ignore_aes=density_ignore, **density_kwargs
+                hist,
+                "hist",
+                data=density,
+                ignore_aes=density_ignore,
+                step_hist=step_hist,
+                **density_kwargs,
             )
 
         else:

--- a/src/arviz_plots/plots/ppcdistplot.py
+++ b/src/arviz_plots/plots/ppcdistplot.py
@@ -28,6 +28,7 @@ def plot_ppc_dist(
     aes_map=None,
     plot_kwargs=None,
     stats_kwargs=None,
+    step_hist=False,
     pc_kwargs=None,
 ):
     """
@@ -90,6 +91,11 @@ def plot_ppc_dist(
         Valid keys are:
 
         * density -> passed to kde, ecdf, ...
+
+    step_hist : boolean, default False
+            Flag to indicate that the `hist` function should be called with
+            the keyword argument `step_hist=True` if step histogram is required
+            instead of bar histogram.
 
     Returns
     -------
@@ -285,6 +291,7 @@ def plot_ppc_dist(
                 "observe_density",
                 data=dt_observed,
                 ignore_aes=observed_ignore,
+                step_hist=step_hist,
                 **observed_density_kwargs,
             )
 

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -13,7 +13,7 @@ import xarray as xr
 from arviz_base.labels import BaseLabeller
 
 
-def hist(da, target, backend, **kwargs):
+def hist(da, target, backend, step_hist=False, **kwargs):
     """Plot a histogram bins(as two arrays of left and right bin edges) vs bin_height('y').
 
     The input argument `da` is split into l_e, r_e and y using the dimension ``plot_axis``.
@@ -24,6 +24,7 @@ def hist(da, target, backend, **kwargs):
         da.sel(plot_axis="left_edges"),
         da.sel(plot_axis="right_edges"),
         target,
+        step_hist=step_hist,
         **kwargs,
     )
 


### PR DESCRIPTION
This implements the new functionality of step histograms discussed in #96 

- To implement step_histogram functionality, it uses `step` function available in matplotlib backend 
- In Bokeh it uses `step` function available in bokeh backend
- In plotly there is no direct function available to achieve this goal, so it uses `go.scatter` functionality to implement step histogram functionality

**step_hist** flag parameter has been added at appropriate places, with default value as False, to maintain compatiblity with old version of functionalities related  to histogram. This new parameter enables users to switch to step histograms just by passing value True to it.

Here are examples using plot_dist function in arviz_plots with flag step_hist as True :

Backend: Plotly
![image](https://github.com/user-attachments/assets/d841df08-10b9-4bb9-bca1-412ca14e5ca5)

Backend: Matplotlib
![image](https://github.com/user-attachments/assets/c7a2e342-1491-4ee6-bb4b-7b77f88b2b6b)

Backend: Bokeh
![image](https://github.com/user-attachments/assets/71ea35ea-4e61-4d0c-824e-0fdac6541223)

