### PR TITLE
Adds square root scale for bokeh and plotly

### DIFF
--- a/src/arviz_plots/plots/ppcrootogramplot.py
+++ b/src/arviz_plots/plots/ppcrootogramplot.py
@@ -314,7 +314,7 @@ def plot_ppc_rootogram(
             **title_kwargs,
         )
 
-    if backend == "matplotlib":
+    if backend in ("matplotlib", "bokeh"):
         plot_collection.map(
             set_y_scale,
             store_artist=False,


### PR DESCRIPTION
Closes #180

Bokeh does not natively support custom scales, so implementing a square root (√y) scale requires a workaround. The set_sqrt_yscale function achieves this by iterating through all renderers (e.g., scatter points, bars) and applying the square root transformation to both the plot data and the y-axis.


![image](https://github.com/user-attachments/assets/898e5a22-e019-495e-a31a-81cfd6dab92d)


<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--178.org.readthedocs.build/en/178/

<!-- readthedocs-preview arviz-plots end -->