### PR TITLE
plot_converge_dist: Add grouped argument

### DIFF
--- a/src/arviz_plots/plots/convergencedistplot.py
+++ b/src/arviz_plots/plots/convergencedistplot.py
@@ -36,9 +36,9 @@ def plot_convergence_dist(
 ):
     """Plot the distribution of convergence diagnostics (ESS and/or R-hat).
 
-    By default all variables are grouped togehter and one plot per diagnostic is created.
-    If you are interested in representing individual (multidimnesional variables) pass them
-    in `var_names`. Additionally, you will need to specify the
+    By default all variables are grouped together and one plot per diagnostic is created.
+    If you are interested in representing individual (multidimensional variables) pass them
+    in `var_names`.
 
     Information on how the diagnostics are computed can be found in [1]_.
 
@@ -137,7 +137,7 @@ def plot_convergence_dist(
         >>>     ]
         >>> )
 
-    Select two variable and plot them separately
+    Select two variables and plot them separately
 
     .. plot::
         :context: close-figs
@@ -145,7 +145,7 @@ def plot_convergence_dist(
         >>> plot_convergence_dist(
         >>>     radon,
         >>>     var_names=["za_county", "a"],
-        >>>     group_by_dimensions=["County"]
+        >>>     grouped=False,
         >>> )
 
     .. minigallery:: plot_convergence_dist


### PR DESCRIPTION
All variables together

```python
azp.plot_convergence_dist(data)
```
![all_grouped](https://github.com/user-attachments/assets/b75a3ef2-1fa2-4293-a55a-fea4a9f65882)

Only `"za_county"` and `"a"` variables

```python
azp.plot_convergence_dist(data),  var_names=["za_county", "a"])
```
![some_grouped](https://github.com/user-attachments/assets/5a1ea74d-8aea-4701-a3db-d98093c5f727)

Only `"za_county"` and `"a"` variables, not together

```python
azp.plot_convergence_dist(data),  var_names=["za_county", "a"], grouped=False)
```
![some_separated](https://github.com/user-attachments/assets/02bf7569-a897-477f-86af-97c9784c2447)

This will fail for `kind="ecdf"` but work for the rest. The reason is that `"g"` has a different shape than (`"za_county"` or `"a"`). This should be fixed in arviz-stats.


```python
azp.plot_convergence_dist(data),  kind="hist", var_names=["za_county", "a", "g"], grouped=False)
```
![some_separated_dim](https://github.com/user-attachments/assets/b9acd37a-7471-4b72-9dc7-fcc7eb224a86)


<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--182.org.readthedocs.build/en/182/

<!-- readthedocs-preview arviz-plots end -->