### PR TITLE
adds sqrt scale for yaxis in plotly

### DIFF
--- a/src/arviz_plots/backend/plotly/__init__.py
+++ b/src/arviz_plots/backend/plotly/__init__.py
@@ -25,6 +25,56 @@ unset = UnsetDefault()
 pat = re.compile(r"^(row|col)\s?:")
 
 
+def apply_square_root_scale(plotly_plot):
+    """Apply a square root scale to the y-axis of a PlotlyPlot."""
+    chart = plotly_plot.chart
+    row = plotly_plot.row
+    col = plotly_plot.col
+
+    if not hasattr(chart.layout, "grid") or chart.layout.grid is None:
+        raise ValueError("The chart does not have a grid layout required for faceting.")
+
+    chart_grid = chart.layout.grid
+    num_cols = chart_grid.columns if chart_grid.columns is not None else 1
+    index = (row - 1) * num_cols + col
+
+    yaxis_ref = "y" if index == 1 else f"y{index}"
+    layout_yaxis = "yaxis" if index == 1 else f"yaxis{index}"
+
+    y_transformed_all = []
+    for trace in chart.data:
+        if getattr(trace, "yaxis", None) == yaxis_ref:
+            if hasattr(trace, "y") and trace.y is not None:
+                y_data = np.array(trace.y, dtype=float)
+                y_data = np.maximum(y_data, 0.0)  # Clamp negative values
+                y_transformed = np.sqrt(y_data)
+                trace.y = y_transformed.tolist()
+                y_transformed_all.extend(y_transformed)
+
+    if not y_transformed_all:
+        return
+
+    y_min = min(y_transformed_all)
+    y_max = max(y_transformed_all)
+
+    tickvals_transformed = []
+    for i in range(int(round(y_max * y_max)) + 1):
+        tickvals_transformed.append(np.sqrt(i))
+
+    if len(tickvals_transformed) == 0:
+        tickvals_transformed = np.array([y_min, y_max])
+
+    ticktext_original = [f"{round(tv**2)}" for tv in tickvals_transformed]
+
+    chart.layout[layout_yaxis].update(
+        tickvals=tickvals_transformed,
+        ticktext=ticktext_original,
+        title=chart.layout[layout_yaxis].title,
+    )
+
+    chart.layout[layout_yaxis].range = [y_min - 0.1, y_max + 0.1]
+
+
 def str_to_plotly_html(string):
     """Convert input string to html subset used by plotly."""
     return string.replace("\n", "<br>")
@@ -581,6 +631,14 @@ def yticks(ticks, labels, target, **artist_kws):
 def xlim(lims, target, **artist_kws):
     """Interface to plotly for setting limits for the x axis."""
     target.update_xaxes(range=lims, **artist_kws)  # pylint: disable=redefined-builtin
+
+
+def set_y_scale(target, scale):
+    """Interface to bokeh for setting the y scale of a plot."""
+    if scale == "sqrt":
+        apply_square_root_scale(target)
+    else:
+        pass
 
 
 def ticklabel_props(target, *, axis="both", size=unset, color=unset, **artist_kws):

--- a/src/arviz_plots/plots/ppcrootogramplot.py
+++ b/src/arviz_plots/plots/ppcrootogramplot.py
@@ -314,7 +314,7 @@ def plot_ppc_rootogram(
             **title_kwargs,
         )
 
-    if backend in ("matplotlib", "bokeh"):
+    if backend in ("matplotlib", "bokeh", "plotly"):
         plot_collection.map(
             set_y_scale,
             store_artist=False,

--- a/src/arviz_plots/plots/ppcrootogramplot.py
+++ b/src/arviz_plots/plots/ppcrootogramplot.py
@@ -314,12 +314,11 @@ def plot_ppc_rootogram(
             **title_kwargs,
         )
 
-    if backend in ("matplotlib", "bokeh", "plotly"):
-        plot_collection.map(
-            set_y_scale,
-            store_artist=False,
-            ignore_aes=plot_collection.aes_set,
-            scale=yscale,
-        )
+    plot_collection.map(
+        set_y_scale,
+        store_artist=False,
+        ignore_aes=plot_collection.aes_set,
+        scale=yscale,
+    )
 
     return plot_collection


### PR DESCRIPTION
Closes #179 and #156

Plotly does not natively support custom scales, so implementing a square root (√y) scale requires a transformation of both the plot data and the y-axis. The `apply_square_root_scale` function achieves this by iterating through all traces in the chart, applying the square root transformation to the y-values, and updating the y-axis tick values and labels accordingly. This ensures that the visual representation maintains interpretability while reflecting the transformed scale.

Example:

**Linear scale plot:**

![image](https://github.com/user-attachments/assets/3d49981c-860e-4f37-984b-ce83a13e4348)

**Square root scale plot:**

![image](https://github.com/user-attachments/assets/df7fd64d-ef3a-4217-8f47-2bf710a0d6f4)



<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--183.org.readthedocs.build/en/183/

<!-- readthedocs-preview arviz-plots end -->