### PR TITLE
adds rule to select fewer ticks in sqrt scale for bokeh and plotly

### DIFF
--- a/src/arviz_plots/backend/bokeh/__init__.py
+++ b/src/arviz_plots/backend/bokeh/__init__.py
@@ -44,8 +44,8 @@ def set_sqrt_yscale(target):
 
     ticks = []
     if max_y > 0:
-        for i in range(math.ceil(max_y) + 1):
-            ticks.append(np.sqrt(i))
+        for i in range(math.ceil(np.sqrt(max_y)) + 1):
+            ticks.append(i)
 
     target.yaxis.formatter = CustomJSTickFormatter(
         code="""

--- a/src/arviz_plots/backend/plotly/__init__.py
+++ b/src/arviz_plots/backend/plotly/__init__.py
@@ -5,6 +5,7 @@ Notes
 :term:`artists` are returned, but it seems modifying them won't modify the figure.
 """
 
+import math
 import re
 import warnings
 
@@ -58,8 +59,8 @@ def apply_square_root_scale(plotly_plot):
     y_max = max(y_transformed_all)
 
     tickvals_transformed = []
-    for i in range(int(round(y_max * y_max)) + 1):
-        tickvals_transformed.append(np.sqrt(i))
+    for i in range(int(math.ceil(y_max)) + 1):
+        tickvals_transformed.append(i)
 
     if len(tickvals_transformed) == 0:
         tickvals_transformed = np.array([y_min, y_max])


### PR DESCRIPTION
closes #184 

Instead of adding all integer ticks within range [0,max_y_value], new rule adds fewer ticks in same range. 

Bokeh:

![image](https://github.com/user-attachments/assets/302dbfeb-d709-4313-b1cb-0c7ae8954872)

Plotly:

![image](https://github.com/user-attachments/assets/51ec7a86-77bf-42b0-b2ff-955c935a77ef)
