### PR TITLE
Add combine_plots, allowing to arrange a set of existing plots into a single chart

### DIFF
--- a/docs/source/api/plots.rst
+++ b/docs/source/api/plots.rst
@@ -17,6 +17,7 @@ A complementary introduction and guide to ``plot_...`` functions is available at
 .. autosummary::
    :toctree: generated/
 
+   combine_plots
    plot_autocorr
    plot_bf
    plot_compare

--- a/docs/source/gallery/mixed/combine_plots.py
+++ b/docs/source/gallery/mixed/combine_plots.py
@@ -1,0 +1,30 @@
+"""
+# Custom diagnostic plots combination 
+
+Column layout with user requested diagnostic plots: ESS evolution plot, rank plot and autocorrelation plot.
+
+---
+
+:::{seealso}
+API Documentation: {func}`~arviz_plots.combine_plots`
+:::
+"""
+from arviz_base import load_arviz_data
+
+import arviz_plots as azp
+
+azp.style.use("arviz-variat")
+
+data = load_arviz_data("non_centered_eight")
+pc = azp.combine_plots(
+    data,
+    [
+        (azp.plot_ess_evolution, {}),
+        (azp.plot_rank, {}),
+        (azp.plot_autocorr, {}),
+    ],
+    var_names=["theta", "mu", "tau"],
+    coords={"school": ["Hotchkiss", "St. Paul's"]},
+    backend="none"  # change to preferred backend
+)
+pc.show()

--- a/docs/source/gallery/mixed/combine_plots.py
+++ b/docs/source/gallery/mixed/combine_plots.py
@@ -26,6 +26,7 @@ pc = azp.combine_plots(
     ],
     var_names=["theta", "mu", "tau"],
     coords={"school": ["Hotchkiss", "St. Paul's"]},
-    backend="none"  # change to preferred backend
+    backend="none",  # change to preferred backend
+    pc_kwargs={"plot_grid_kws": {"figsize": (10, 7)}}
 )
 pc.show()

--- a/docs/source/gallery/mixed/combine_plots.py
+++ b/docs/source/gallery/mixed/combine_plots.py
@@ -2,7 +2,7 @@
 # Custom diagnostic plots combination 
 
 Arrange three diagnostic plots (ESS evolution plot, rank plot and autocorrelation plot)
-in a custom row layout.
+in a custom column layout.
 
 ---
 
@@ -26,7 +26,6 @@ pc = azp.combine_plots(
     ],
     var_names=["theta", "mu", "tau"],
     coords={"school": ["Hotchkiss", "St. Paul's"]},
-    expand="row",
     backend="none"  # change to preferred backend
 )
 pc.show()

--- a/docs/source/gallery/mixed/combine_plots.py
+++ b/docs/source/gallery/mixed/combine_plots.py
@@ -1,7 +1,8 @@
 """
 # Custom diagnostic plots combination 
 
-Column layout with user requested diagnostic plots: ESS evolution plot, rank plot and autocorrelation plot.
+Arrange three diagnostic plots (ESS evolution plot, rank plot and autocorrelation plot)
+in a custom row layout.
 
 ---
 
@@ -25,6 +26,7 @@ pc = azp.combine_plots(
     ],
     var_names=["theta", "mu", "tau"],
     coords={"school": ["Hotchkiss", "St. Paul's"]},
+    expand="row",
     backend="none"  # change to preferred backend
 )
 pc.show()

--- a/docs/sphinxext/gallery_generator.py
+++ b/docs/sphinxext/gallery_generator.py
@@ -102,7 +102,7 @@ def main(app):
 
     index_page = ["(example_gallery)=\n# Example gallery"]
     backreferences = defaultdict(list)
-    api_regex = re.compile(r"azp\.(plot_[a-z_]+)\(")
+    api_regex = re.compile(r"azp\.(plot_[a-z_]+|combine_plots)\(")
 
     for folder, title in dir_title_map.items():
         category_dir = gallery_dir / folder

--- a/src/arviz_plots/backend/none/__init__.py
+++ b/src/arviz_plots/backend/none/__init__.py
@@ -196,7 +196,7 @@ def hist(
     r_e,
     target,
     *,
-    bottom=None,
+    bottom=0,
     color=unset,
     facecolor=unset,
     edgecolor=unset,
@@ -287,7 +287,7 @@ def step(x, y, target, *, color=unset, alpha=unset, width=unset, linestyle=unset
     if not ALLOW_KWARGS and artist_kws:
         raise ValueError("artist_kws not empty")
     artist_element = {
-        "function": "line",
+        "function": "step",
         "x": np.atleast_1d(x),
         "y": np.atleast_1d(y),
         **_filter_kwargs(kwargs, artist_kws),
@@ -398,7 +398,7 @@ def ciliney(
     if not ALLOW_KWARGS and artist_kws:
         raise ValueError("artist_kws not empty")
     artist_element = {
-        "function": "line",
+        "function": "ciliney",
         "x": np.atleast_1d(x),
         "y_bottom": np.atleast_1d(y_bottom),
         "y_top": np.atleast_1d(y_top),
@@ -491,6 +491,27 @@ def remove_axis(target, axis="y"):
     artist_element = {
         "function": "remove_axis",
         "axis": axis,
+    }
+    target.append(artist_element)
+    return artist_element
+
+
+def set_y_scale(target, scale):
+    """Interface to setting the y scale of a plot."""
+    artist_element = {
+        "function": "set_y_scale",
+        "scale": scale,
+    }
+    target.append(artist_element)
+    return artist_element
+
+
+def grid(target, axis, color):
+    """Interface to setting a grid in any axis."""
+    artist_element = {
+        "function": "grid",
+        "axis": axis,
+        "color": color,
     }
     target.append(artist_element)
     return artist_element

--- a/src/arviz_plots/plot_collection.py
+++ b/src/arviz_plots/plot_collection.py
@@ -855,10 +855,13 @@ class PlotCollection:
         all_loop_dims = self.base_loop_dims.union(aes_dims).difference(coords.keys())
         return aes, all_loop_dims
 
-    def allocate_artist(self, fun_label, data, all_loop_dims, artist_dims=None):
+    def allocate_artist(self, fun_label, data, all_loop_dims, artist_dims=None, ignore_aes=None):
         """Allocate an artist in the ``viz`` DataTree."""
         if artist_dims is None:
             artist_dims = {}
+        attrs = None
+        if ignore_aes is not None:
+            attrs = {"ignore_aes": ignore_aes}
         for var_name, da in data.items():
             if var_name not in self.viz.children:
                 self.viz[var_name] = xr.DataTree()
@@ -871,6 +874,7 @@ class PlotCollection:
                 np.full(artist_shape, None, dtype=object),
                 dims=all_artist_dims,
                 coords={dim: data[dim] for dim in inherited_dims},
+                attrs=attrs,
             )
 
     def get_target(self, var_name, selection):
@@ -1015,6 +1019,7 @@ class PlotCollection:
                 data=loop_data,
                 all_loop_dims=all_loop_dims,
                 artist_dims=artist_dims,
+                ignore_aes=ignore_aes,
             )
 
         for var_name, sel, isel in plotters:

--- a/src/arviz_plots/plot_collection.py
+++ b/src/arviz_plots/plot_collection.py
@@ -689,8 +689,8 @@ class PlotCollection:
                 {
                     "chart": np.array(fig, dtype=object),
                     "plot": (dims, flat_ax_ary.reshape(plots_raw_shape)),
-                    "row": (dims, flat_row_id.reshape(plots_raw_shape)),
-                    "col": (dims, flat_col_id.reshape(plots_raw_shape)),
+                    "row_index": (dims, flat_row_id.reshape(plots_raw_shape)),
+                    "col_index": (dims, flat_col_id.reshape(plots_raw_shape)),
                 },
                 coords={dim: data[dim] for dim in dims},
             )
@@ -713,11 +713,11 @@ class PlotCollection:
                             dims,
                             flat_ax_ary[col_slice].reshape(plots_raw_shape),
                         ),
-                        "row": (
+                        "row_index": (
                             dims,
                             flat_row_id[col_slice].reshape(plots_raw_shape),
                         ),
-                        "col": (
+                        "col_index": (
                             dims,
                             flat_col_id[col_slice].reshape(plots_raw_shape),
                         ),
@@ -800,8 +800,8 @@ class PlotCollection:
                 {
                     "chart": np.array(fig, dtype=object),
                     "plot": (dims, ax_ary.flatten().reshape(plots_raw_shape)),
-                    "row": (dims, row_id.flatten().reshape(plots_raw_shape)),
-                    "col": (dims, col_id.flatten().reshape(plots_raw_shape)),
+                    "row_index": (dims, row_id.flatten().reshape(plots_raw_shape)),
+                    "col_index": (dims, col_id.flatten().reshape(plots_raw_shape)),
                 },
                 coords={dim: data[dim] for dim in dims},
             )
@@ -832,11 +832,11 @@ class PlotCollection:
                             dims,
                             ax_ary[row_slice, col_slice].flatten().reshape(plots_raw_shape),
                         ),
-                        "row": (
+                        "row_index": (
                             dims,
                             row_id[row_slice, col_slice].flatten().reshape(plots_raw_shape),
                         ),
-                        "col": (
+                        "col_index": (
                             dims,
                             col_id[row_slice, col_slice].flatten().reshape(plots_raw_shape),
                         ),
@@ -1019,8 +1019,11 @@ class PlotCollection:
 
         for var_name, sel, isel in plotters:
             da = data[var_name].sel(sel)
-            if np.all(np.isnan(da)):
-                continue
+            try:
+                if np.all(np.isnan(da)):
+                    continue
+            except TypeError:
+                pass
             sel_plus = {**sel, **coords}
             target = self.get_target(var_name, sel_plus)
 

--- a/src/arviz_plots/plots/__init__.py
+++ b/src/arviz_plots/plots/__init__.py
@@ -2,6 +2,7 @@
 
 from .autocorr_plot import plot_autocorr
 from .bf_plot import plot_bf
+from .combine import combine_plots
 from .compare_plot import plot_compare
 from .convergence_dist_plot import plot_convergence_dist
 from .dist_plot import plot_dist
@@ -24,6 +25,7 @@ from .trace_dist_plot import plot_trace_dist
 from .trace_plot import plot_trace
 
 __all__ = [
+    "combine_plots",
     "plot_autocorr",
     "plot_bf",
     "plot_compare",

--- a/src/arviz_plots/plots/combine.py
+++ b/src/arviz_plots/plots/combine.py
@@ -1,3 +1,4 @@
+"""Elements to combine multiple batteries-included plots into a single chart."""
 import re
 from importlib import import_module
 
@@ -8,6 +9,24 @@ from arviz_plots import PlotCollection
 from arviz_plots.plots.utils import process_group_variables_coords, set_figure_layout
 
 def get_valid_arg(key, value, backend):
+    """Convert none backend aesthetic argument indicator to a valid value for the given backend.
+
+    Parameters
+    ----------
+    key : str
+        The keyword part of the :ref:`backend-interface-arguments` for which `value` should
+        be valid.
+    value : any
+        The current value for `key`. It might be an indicator from the none backend such as
+        "color_0" or "linestyle_3" which gets processed or something else in which case
+        it is assumed to be a valid argument already and returned as is.
+    backend : str
+        The backend for which `value` should be valid.
+
+    Returns
+    -------
+    valid_value : any
+    """
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
     key_matcher = "color" if key in {"facecolor", "edgecolor"} else key
     if isinstance(value, str):
@@ -19,9 +38,11 @@ def get_valid_arg(key, value, backend):
 
 
 def backendize_kwargs(kwargs, backend):
+    """Process the artist description dictionary from the none backend to valid kwargs."""
     return {key: get_valid_arg(key, value, backend) for key, value in kwargs.items() if key != "function"}
 
 def render(da, target, backend, **kwargs):
+    """Render artist descriptions from the none backend with a plotting backend."""
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
     plot_kwargs = da.item()
     plot_fun_name = plot_kwargs["function"]
@@ -31,40 +52,121 @@ def render(da, target, backend, **kwargs):
 
 def combine_plots(
     dt,
-    plots=None,
-    expanded_dim="column",
-    expanded_coord_names=None,
-    group="posterior",
+    plots,
     var_names=None,
     filter_vars=None,
+    group="posterior",
     coords=None,
-    backend="matplotlib",
+    sample_dims=None,
+    expand="column",
+    plot_names=None,
+    backend=None,
+    pc_kwargs=None,
 ):
-    if expanded_coord_names is None:
-        expanded_coord_names = [
+    """Create a grid by combining multiple batteries-included plots in the same :term:`chart`.
+
+    Parameters
+    ----------
+    dt : DataTree of dict of {str : DataTree}
+        Input data. In case of dictionary input, the keys are taken to be model names.
+        In such cases, a dimension "model" is generated and can be used to map to aesthetics.
+
+        Note that not all batteries included functions accept dictionary input, so it will
+        only work when all plotting functions requested in `plots` are compatible with it.
+    plots : list of tuple of (callable, mapping)
+        List of all the plotting functions to be combined. Each element in this list
+        is a tuple with two elements. The first is the function to be called, the second
+        is a dictionary with any keyword arguments that should be used when calling that function.
+    var_names : str or sequence of str, optional
+        One or more variables to be plotted.
+        Prefix the variables by ~ when you want to exclude them from the plot.
+    filter_vars : {None, “like”, “regex”}, default None
+        If None, interpret `var_names` as the real variables names.
+        If “like”, interpret `var_names` as substrings of the real variables names.
+        If “regex”, interpret `var_names` as regular expressions on the real variables names.
+    group : str, default "posterior"
+        Group to be plotted.
+    coords : dict, optional
+    sample_dims : str or sequence of hashable, optional
+        Dimensions to reduce unless mapped to an aesthetic.
+        Defaults to ``rcParams["data.sample_dims"]``
+    expand : {"column", "row"}, default "column"
+        How to combine the different plotting functions. If "column", each plotting function
+        will be added as a new column, if "row" it will be a new row instead.
+    plot_names : list of str, optional
+        List of the same length as `plots` with the plot names to use as coordinate values
+        in the returned :class:`~arviz_plots.PlotCollection`. 
+    backend : {"matplotlib", "bokeh", "plotly"}, optional
+        Plotting backend to use. Defaults to ``rcParams["plot.backend"]``.
+    pc_kwargs : mapping, optional
+        Passed to :class:`arviz_plots.PlotCollection.grid`
+
+    Returns
+    -------
+    PlotCollection
+
+    Examples
+    --------
+    Customize the names of the plots in the returned :class:`PlotCollection`
+
+    .. plot::
+        :context: close-figs
+
+        >>> import arviz_plots as azp
+        >>> azp.style.use("arviz-variat")
+        >>> from arviz_base import load_arviz_data
+        >>> rugby = load_arviz_data('rugby')
+        >>> pc = azp.combine_plots(
+        >>>     rugby,
+        >>>     plots=[
+        >>>         (azp.plot_ppc_pit, {}),
+        >>>         (azp.plot_ppc_rootogram, {}),
+        >>>     ],
+        >>>     group="posterior_predictive",
+        >>>     plot_names=["pit", "rootogram"],
+        >>> )
+
+    Now if we inspect the ``pc.viz`` attribute, we can see it has a ``column`` dimension
+    with the requested coordinate values:
+
+    .. plot::
+        :context: close-figs
+
+        >>> pc.viz
+
+
+    .. minigallery:: combine_plots
+    """
+    if plot_names is None:
+        plot_names = [
             getattr(elem[0], "__name__") + f"_{idx:02d}" for idx, elem in enumerate(plots)
         ]
-    sample_dims = rcParams["data.sample_dims"]
-    column_length = len(expanded_coord_names)
+    if sample_dims is None:
+        sample_dims = rcParams["data.sample_dims"]
+    if isinstance(sample_dims, str):
+        sample_dims = [sample_dims]
 
     distribution = process_group_variables_coords(
         dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords
     )
     facet_dims = ["__variable__"] + ([] if "predictive" in group else [dim for dim in distribution.dims if dim not in sample_dims])
 
-    pc_kwargs = {}
-    pc_kwargs["plot_grid_kws"] = {}
-    if expanded_dim == "column":
-        pc_kwargs.setdefault("cols", ["column"])
-        pc_kwargs["rows"] = facet_dims
-        expand_dims = {"column": column_length}
-    elif expanded_dim == "row":
-        pc_kwargs["cols"] = facet_dims
-        pc_kwargs["rows"] = ["row"]
-        expand_dims = {"row": column_length}
+    if pc_kwargs is None:
+        pc_kwargs = {}
     else:
-        raise ValueError(f"`expanded_dim` must be 'row' or 'column' but got '{expanded_dim}'")
-    distribution = distribution.expand_dims(**expand_dims).assign_coords({expanded_dim: expanded_coord_names})
+        pc_kwargs = pc_kwargs.copy()
+    pc_kwargs["plot_grid_kws"] = pc_kwargs.get("plot_grid_kws", {}).copy()
+    if expand == "column":
+        pc_kwargs.setdefault("cols", ["column"])
+        pc_kwargs.setdefault("rows", facet_dims)
+        expand_kwargs = {"column": len(plots)}
+    elif expand == "row":
+        pc_kwargs.setdefault("cols", facet_dims)
+        pc_kwargs.setdefault("rows", ["row"])
+        expand_kwargs = {"row": len(plots)}
+    else:
+        raise ValueError(f"`expand` must be 'row' or 'column' but got '{expand}'")
+    distribution = distribution.expand_dims(**expand_kwargs).assign_coords({expand: plot_names})
 
     plot_bknd = import_module(f".backend.{backend}", package="arviz_plots")
     pc_kwargs = set_figure_layout(pc_kwargs, plot_bknd, distribution)
@@ -75,7 +177,7 @@ def combine_plots(
         **pc_kwargs,
     )
 
-    for name, (plot, kwargs) in zip(expanded_coord_names, plots):
+    for name, (plot, kwargs) in zip(plot_names, plots):
         pc_i = plot(
             dt, backend="none", group=group,
             var_names=var_names, filter_vars=filter_vars,
@@ -83,7 +185,7 @@ def combine_plots(
         )
         pc.coords = None
         pc.aes = pc_i.aes
-        pc.coords = {expanded_dim: name}
+        pc.coords = {expand: name}
         inverted_dt_dict = {}
         for viz_group, ds in pc_i.viz.children.items():
             for viz_var_name, da in ds.data_vars.items():
@@ -95,7 +197,14 @@ def combine_plots(
         inverted_dt_dict = {key: xr.Dataset(values) for key, values in inverted_dt_dict.items()}
         for viz_group, ds in inverted_dt_dict.items():
             attrs = ds[list(ds.data_vars)[0]].attrs
-            pc.map(render, fun_label=f"{viz_group}_{name}", data=ds, ignore_aes=attrs.get("ignore_aes", None))
+            pc.map(
+                render,
+                fun_label=f"{viz_group}_{name}",
+                data=ds,
+                ignore_aes=attrs.get("ignore_aes", None)
+            )
     pc.coords = None
+    # TODO: at some point all `pc_i.aes` objects should be merged
+    # and stored into the `pc.aes` attribute
 
     return pc

--- a/src/arviz_plots/plots/combine.py
+++ b/src/arviz_plots/plots/combine.py
@@ -8,6 +8,7 @@ from arviz_base import rcParams
 from arviz_plots import PlotCollection
 from arviz_plots.plots.utils import process_group_variables_coords, set_figure_layout
 
+
 def get_valid_arg(key, value, backend):
     """Convert none backend aesthetic argument indicator to a valid value for the given backend.
 
@@ -30,16 +31,21 @@ def get_valid_arg(key, value, backend):
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
     key_matcher = "color" if key in {"facecolor", "edgecolor"} else key
     if isinstance(value, str):
-        match = re.match(key_matcher +"_([0-9]+)", value)
+        match = re.match(key_matcher + "_([0-9]+)", value)
         if match:
             index = int(match.groups()[0])
-            return plot_backend.get_default_aes(key, index+1)[index]
+            return plot_backend.get_default_aes(key, index + 1)[index]
     return value
 
 
 def backendize_kwargs(kwargs, backend):
     """Process the artist description dictionary from the none backend to valid kwargs."""
-    return {key: get_valid_arg(key, value, backend) for key, value in kwargs.items() if key != "function"}
+    return {
+        key: get_valid_arg(key, value, backend)
+        for key, value in kwargs.items()
+        if key != "function"
+    }
+
 
 def render(da, target, backend, **kwargs):
     """Render artist descriptions from the none backend with a plotting backend."""
@@ -49,6 +55,7 @@ def render(da, target, backend, **kwargs):
     plot_kwargs = backendize_kwargs(plot_kwargs, backend)
     kwargs = backendize_kwargs(kwargs, backend)
     return getattr(plot_backend, plot_fun_name)(target=target, **{**plot_kwargs, **kwargs})
+
 
 def combine_plots(
     dt,
@@ -95,7 +102,7 @@ def combine_plots(
         will be added as a new column, if "row" it will be a new row instead.
     plot_names : list of str, optional
         List of the same length as `plots` with the plot names to use as coordinate values
-        in the returned :class:`~arviz_plots.PlotCollection`. 
+        in the returned :class:`~arviz_plots.PlotCollection`.
     backend : {"matplotlib", "bokeh", "plotly"}, optional
         Plotting backend to use. Defaults to ``rcParams["plot.backend"]``.
     pc_kwargs : mapping, optional
@@ -149,7 +156,11 @@ def combine_plots(
     distribution = process_group_variables_coords(
         dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords
     )
-    facet_dims = ["__variable__"] + ([] if "predictive" in group else [dim for dim in distribution.dims if dim not in sample_dims])
+    facet_dims = ["__variable__"] + (
+        []
+        if "predictive" in group
+        else [dim for dim in distribution.dims if dim not in sample_dims]
+    )
 
     if pc_kwargs is None:
         pc_kwargs = {}
@@ -179,9 +190,13 @@ def combine_plots(
 
     for name, (plot, kwargs) in zip(plot_names, plots):
         pc_i = plot(
-            dt, backend="none", group=group,
-            var_names=var_names, filter_vars=filter_vars,
-            coords=coords, **kwargs
+            dt,
+            backend="none",
+            group=group,
+            var_names=var_names,
+            filter_vars=filter_vars,
+            coords=coords,
+            **kwargs,
         )
         pc.coords = None
         pc.aes = pc_i.aes
@@ -201,7 +216,7 @@ def combine_plots(
                 render,
                 fun_label=f"{viz_group}_{name}",
                 data=ds,
-                ignore_aes=attrs.get("ignore_aes", None)
+                ignore_aes=attrs.get("ignore_aes", None),
             )
     pc.coords = None
     # TODO: at some point all `pc_i.aes` objects should be merged

--- a/src/arviz_plots/plots/combine.py
+++ b/src/arviz_plots/plots/combine.py
@@ -1,6 +1,31 @@
+import re
+from importlib import import_module
+
+import xarray as xr
+from arviz_base import rcParams
+
 from arviz_plots import PlotCollection
 from arviz_plots.plots.utils import process_group_variables_coords
 
+def get_valid_arg(key, value, backend):
+    plot_backend = import_module(f"arviz_plots.backend.{backend}")
+    key_matcher = "color" if key in {"facecolor", "edgecolor"} else key
+    if isinstance(value, str) and re.match(key_matcher +"_[0-9]+", value):
+        _, index = value.rsplit("_", 1)
+        index = int(index)
+        return plot_backend.get_default_aes(key, index+1)[index]
+    return value
+
+
+def backendize_kwargs(kwargs, backend):
+    return {key: get_valid_arg(key, value, backend) for key, value in kwargs.items() if key != "function"}
+
+def render(da, target, backend, **kwargs):
+    plot_backend = import_module(f"arviz_plots.backend.{backend}")
+    plot_kwargs = da.item()
+    plot_fun_name = plot_kwargs["function"]
+    plot_kwargs = backendize_kwargs(plot_kwargs, backend)
+    return getattr(plot_backend, plot_fun_name)(target=target, **{**plot_kwargs, **kwargs})
 
 def combine_plots(
     dt,
@@ -11,39 +36,60 @@ def combine_plots(
     var_names=None,
     filter_vars=None,
     coords=None,
+    backend="matplotlib",
 ):
     if expanded_coord_names is None:
         expanded_coord_names = [
             getattr(elem[0], "__name__") + f"_{idx:02d}" for idx, elem in enumerate(plots)
         ]
-
+    sample_dims = rcParams["data.sample_dims"]
     column_length = len(expanded_coord_names)
 
     distribution = process_group_variables_coords(
         dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords
     )
+    facet_dims = ["__variable__"] + ([] if "predictive" in group else [dim for dim in distribution.dims if dim not in sample_dims])
 
     pc_kwargs = {}
     pc_kwargs["plot_grid_kws"] = {}
     if expanded_dim == "column":
         pc_kwargs.setdefault("cols", ["column"])
-        pc_kwargs["rows"] = ["__variable__"]
+        pc_kwargs["rows"] = facet_dims
         expand_dims = {"column": column_length}
-    if expanded_dim == "row":
-        pc_kwargs["cols"] = ["__variable__"]
+    elif expanded_dim == "row":
+        pc_kwargs["cols"] = facet_dims
         pc_kwargs["rows"] = ["row"]
         expand_dims = {"row": column_length}
+    else:
+        raise ValueError()
 
     pc_kwargs["plot_grid_kws"]["figsize"] = (12, 3)
 
     pc = PlotCollection.grid(
-        distribution.expand_dims(**expand_dims).assign_coords(column=expanded_coord_names),
-        backend="matplotlib",
+        distribution.expand_dims(**expand_dims).assign_coords({expanded_dim: expanded_coord_names}),
+        backend=backend,
         **pc_kwargs,
     )
 
     for name, (plot, kwargs) in zip(expanded_coord_names, plots):
+        pc_i = plot(
+            dt, backend="none", group=group,
+            var_names=var_names, filter_vars=filter_vars,
+            coords=coords, **kwargs
+        )
+        pc.coords = None
+        pc.aes = pc_i.aes
         pc.coords = {expanded_dim: name}
-        plot(dt, **kwargs, var_names=var_names, group=group, plot_collection=pc)
+        inverted_dt = {}
+        for viz_group, ds in pc_i.viz.children.items():
+            for viz_var_name, da in ds.data_vars.items():
+                if viz_var_name in {"plot", "row_index", "col_index"}:
+                    continue
+                if viz_var_name not in inverted_dt:
+                    inverted_dt[viz_var_name] = {}
+                inverted_dt[viz_var_name].update({viz_group: da})
+        inverted_dt = xr.DataTree.from_dict({key: xr.Dataset(values) for key, values in inverted_dt.items()})
+        for viz_group, ds in inverted_dt.children.items():
+            pc.map(render, data=ds.dataset, store_artist=False)
 
     return pc

--- a/src/arviz_plots/plots/combine.py
+++ b/src/arviz_plots/plots/combine.py
@@ -152,6 +152,8 @@ def combine_plots(
         sample_dims = rcParams["data.sample_dims"]
     if isinstance(sample_dims, str):
         sample_dims = [sample_dims]
+    if backend is None:
+        backend = rcParams["plot.backend"]
 
     distribution = process_group_variables_coords(
         dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords

--- a/src/arviz_plots/plots/combine.py
+++ b/src/arviz_plots/plots/combine.py
@@ -70,7 +70,7 @@ def combine_plots(
     backend=None,
     pc_kwargs=None,
 ):
-    """Create a grid by combining multiple batteries-included plots in the same :term:`chart`.
+    """Arrange multiple batteries-included plots in a customizable column or row layout.
 
     Parameters
     ----------

--- a/src/arviz_plots/plots/combine.py
+++ b/src/arviz_plots/plots/combine.py
@@ -1,0 +1,49 @@
+from arviz_plots import PlotCollection
+from arviz_plots.plots.utils import process_group_variables_coords
+
+
+def combine_plots(
+    dt,
+    plots=None,
+    expanded_dim="column",
+    expanded_coord_names=None,
+    group="posterior",
+    var_names=None,
+    filter_vars=None,
+    coords=None,
+):
+    if expanded_coord_names is None:
+        expanded_coord_names = [
+            getattr(elem[0], "__name__") + f"_{idx:02d}" for idx, elem in enumerate(plots)
+        ]
+
+    column_length = len(expanded_coord_names)
+
+    distribution = process_group_variables_coords(
+        dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords
+    )
+
+    pc_kwargs = {}
+    pc_kwargs["plot_grid_kws"] = {}
+    if expanded_dim == "column":
+        pc_kwargs.setdefault("cols", ["column"])
+        pc_kwargs["rows"] = ["__variable__"]
+        expand_dims = {"column": column_length}
+    if expanded_dim == "row":
+        pc_kwargs["cols"] = ["__variable__"]
+        pc_kwargs["rows"] = ["row"]
+        expand_dims = {"row": column_length}
+
+    pc_kwargs["plot_grid_kws"]["figsize"] = (12, 3)
+
+    pc = PlotCollection.grid(
+        distribution.expand_dims(**expand_dims).assign_coords(column=expanded_coord_names),
+        backend="matplotlib",
+        **pc_kwargs,
+    )
+
+    for name, (plot, kwargs) in zip(expanded_coord_names, plots):
+        pc.coords = {expanded_dim: name}
+        plot(dt, **kwargs, var_names=var_names, group=group, plot_collection=pc)
+
+    return pc

--- a/src/arviz_plots/plots/dist_plot.py
+++ b/src/arviz_plots/plots/dist_plot.py
@@ -410,7 +410,10 @@ def plot_dist(
         )
     if plot_kwargs.get("remove_axis", True) is not False:
         plot_collection.map(
-            remove_axis, store_artist=backend == "none", axis="y", ignore_aes=plot_collection.aes_set
+            remove_axis,
+            store_artist=backend == "none",
+            axis="y",
+            ignore_aes=plot_collection.aes_set,
         )
 
     return plot_collection

--- a/src/arviz_plots/plots/dist_plot.py
+++ b/src/arviz_plots/plots/dist_plot.py
@@ -410,7 +410,7 @@ def plot_dist(
         )
     if plot_kwargs.get("remove_axis", True) is not False:
         plot_collection.map(
-            remove_axis, store_artist=False, axis="y", ignore_aes=plot_collection.aes_set
+            remove_axis, store_artist=backend == "none", axis="y", ignore_aes=plot_collection.aes_set
         )
 
     return plot_collection

--- a/src/arviz_plots/plots/ecdf_plot.py
+++ b/src/arviz_plots/plots/ecdf_plot.py
@@ -213,6 +213,7 @@ def plot_ecdf_pit(
             "ecdf_xticks",
             values=[0, 0.25, 0.5, 0.75, 1],
             labels=["0", "25", "50", "75", "100"],
+            store_artist=backend == "none",
         )
 
     ci_kwargs = copy(plot_kwargs.get("ci", {}))
@@ -285,7 +286,10 @@ def plot_ecdf_pit(
 
     if plot_kwargs.get("remove_axis", True) is not False:
         plot_collection.map(
-            remove_axis, store_artist=False, axis="y", ignore_aes=plot_collection.aes_set
+            remove_axis,
+            store_artist=backend == "none",
+            axis="y",
+            ignore_aes=plot_collection.aes_set,
         )
 
     return plot_collection

--- a/src/arviz_plots/plots/forest_plot.py
+++ b/src/arviz_plots/plots/forest_plot.py
@@ -524,7 +524,10 @@ def plot_forest(
 
     if plot_kwargs.get("remove_axis", True) is not False:
         plot_collection.map(
-            remove_axis, store_artist=False, axis="y", ignore_aes=plot_collection.aes_set
+            remove_axis,
+            store_artist=backend == "none",
+            axis="y",
+            ignore_aes=plot_collection.aes_set,
         )
 
     return plot_collection

--- a/src/arviz_plots/plots/ppc_pit_plot.py
+++ b/src/arviz_plots/plots/ppc_pit_plot.py
@@ -248,6 +248,7 @@ def plot_ppc_pit(
             "ecdf_xticks",
             values=[0, 0.25, 0.5, 0.75, 1],
             labels=["0", "25", "50", "75", "100"],
+            store_artist=backend == "none",
         )
 
     ci_kwargs = copy(plot_kwargs.get("ci", {}))

--- a/src/arviz_plots/plots/ppc_rootogram_plot.py
+++ b/src/arviz_plots/plots/ppc_rootogram_plot.py
@@ -322,7 +322,7 @@ def plot_ppc_rootogram(
 
     plot_collection.map(
         set_y_scale,
-        store_artist=False,
+        store_artist=backend == "none",
         ignore_aes=plot_collection.aes_set,
         scale=yscale,
     )

--- a/src/arviz_plots/plots/psense_quantities_plot.py
+++ b/src/arviz_plots/plots/psense_quantities_plot.py
@@ -377,6 +377,7 @@ def plot_psense_quantities(
         values=alphas_p1,
         labels=alphas_p1_labels,
         ignore_aes=ticks_ignore,
+        store_artist=backend == "none",
         **ticks_kwargs,
     )
 

--- a/src/arviz_plots/plots/rank_plot.py
+++ b/src/arviz_plots/plots/rank_plot.py
@@ -243,7 +243,10 @@ def plot_rank(
 
     if plot_kwargs.get("remove_axis", True) is not False:
         plot_collection.map(
-            remove_axis, store_artist=False, axis="y", ignore_aes=plot_collection.aes_set
+            remove_axis,
+            store_artist=backend == "none",
+            axis="y",
+            ignore_aes=plot_collection.aes_set,
         )
 
     return plot_collection

--- a/src/arviz_plots/plots/ridge_plot.py
+++ b/src/arviz_plots/plots/ridge_plot.py
@@ -495,7 +495,10 @@ def plot_ridge(
 
     if plot_kwargs.get("remove_axis", True) is not False:
         plot_collection.map(
-            remove_axis, store_artist=False, axis="y", ignore_aes=plot_collection.aes_set
+            remove_axis,
+            store_artist=backend == "none",
+            axis="y",
+            ignore_aes=plot_collection.aes_set,
         )
 
     return plot_collection

--- a/src/arviz_plots/plots/trace_dist_plot.py
+++ b/src/arviz_plots/plots/trace_dist_plot.py
@@ -395,7 +395,7 @@ def plot_trace_dist(
             coords={"column": "dist"},
             subset_info=True,
             labeller=labeller,
-            store_artist=False,
+            store_artist=backend == "none",
             **label_kwargs,
         )
 
@@ -406,7 +406,7 @@ def plot_trace_dist(
             coords={"column": "trace"},
             subset_info=True,
             labeller=labeller,
-            store_artist=False,
+            store_artist=backend == "none",
             **label_kwargs,
         )
 
@@ -418,7 +418,7 @@ def plot_trace_dist(
             ticklabel_props,
             ignore_aes=ticklabels_ignore,
             axis="both",
-            store_artist=False,
+            store_artist=backend == "none",
             **ticklabels_kwargs,
         )
 

--- a/src/arviz_plots/plots/trace_plot.py
+++ b/src/arviz_plots/plots/trace_plot.py
@@ -121,8 +121,8 @@ def plot_trace(
             n_cols = col_wrap
     else:
         figsize, figsize_units = plot_bknd.get_figsize(plot_collection)
-        n_rows = leaf_dataset(plot_collection.viz, "row").max().to_array().max().item()
-        n_cols = leaf_dataset(plot_collection.viz, "col").max().to_array().max().item()
+        n_rows = leaf_dataset(plot_collection.viz, "row_index").max().to_array().max().item()
+        n_cols = leaf_dataset(plot_collection.viz, "col_index").max().to_array().max().item()
 
     figsize = plot_bknd.scale_fig_size(
         figsize,
@@ -254,7 +254,7 @@ def plot_trace(
             ticklabel_props,
             ignore_aes=ticklabels_ignore,
             axis="both",
-            store_artist=False,
+            store_artist=backend == "none",
             **ticklabels_kwargs,
         )
 

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -289,28 +289,28 @@ def ticklabel_props(da, target, backend, **kwargs):
 def remove_axis(da, target, backend, **kwargs):
     """Dispatch to ``remove_axis`` function in backend."""
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
-    plot_backend.remove_axis(target, **kwargs)
+    return plot_backend.remove_axis(target, **kwargs)
 
 
 def remove_ticks(da, target, backend, **kwargs):
     """Dispatch to ``remove_axis`` function in backend."""
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
-    plot_backend.remove_ticks(target, **kwargs)
+    return plot_backend.remove_ticks(target, **kwargs)
 
 
 def set_xticks(da, target, backend, values, labels, **kwargs):
     """Dispatch to ``set_xticks`` function in backend."""
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
-    plot_backend.xticks(values, labels, target, **kwargs)
+    return plot_backend.xticks(values, labels, target, **kwargs)
 
 
 def set_y_scale(da, target, backend, scale, **kwargs):
     """Set scale for y-axis."""
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
-    plot_backend.set_y_scale(target, scale, **kwargs)
+    return plot_backend.set_y_scale(target, scale, **kwargs)
 
 
 def grid(da, target, backend, **kwargs):
     """Dispatch to ``remove_axis`` function in backend."""
     plot_backend = import_module(f"arviz_plots.backend.{backend}")
-    plot_backend.grid(target, **kwargs)
+    return plot_backend.grid(target, **kwargs)

--- a/tests/test_plot_collection.py
+++ b/tests/test_plot_collection.py
@@ -33,8 +33,8 @@ class Testfaceting:
         )
         assert "plot" in pc.viz.data_vars
         assert pc.viz["plot"].shape == (7,)
-        assert pc.viz["row"].max() == 1
-        assert pc.viz["col"].max() == 3
+        assert pc.viz["row_index"].max() == 1
+        assert pc.viz["col_index"].max() == 3
 
     def test_wrap_variable(self, dataset, backend):
         pc = PlotCollection.wrap(dataset, backend=backend, cols=["__variable__", "group"])
@@ -81,7 +81,7 @@ class Testfaceting:
         assert pc.viz["plot"].sizes["chain"] == 3
         assert "hierarchy" not in pc.viz["plot"].dims
         assert "group" not in pc.viz["plot"].dims
-        assert pc.viz["row" if axis == "cols" else "col"].max() == 0
+        assert pc.viz["row_index" if axis == "cols" else "col_index"].max() == 0
         assert pc.viz[axis[:3]].max() == 2
 
     def test_grid_variable(self, dataset, backend):

--- a/tests/test_plot_collection.py
+++ b/tests/test_plot_collection.py
@@ -82,7 +82,7 @@ class Testfaceting:
         assert "hierarchy" not in pc.viz["plot"].dims
         assert "group" not in pc.viz["plot"].dims
         assert pc.viz["row_index" if axis == "cols" else "col_index"].max() == 0
-        assert pc.viz[axis[:3]].max() == 2
+        assert pc.viz["col_index" if axis == "cols" else "row_index"].max() == 2
 
     def test_grid_variable(self, dataset, backend):
         pc = PlotCollection.grid(


### PR DESCRIPTION
A common task for presenting results is combining different plots in a single figure. This can be done with image editing tools. But that can be overkill for simple tasks like adding a couple of plots side by side.

Here, I am sharing a possible approach to that, but not sure if this is the best route. Before keep working on this solution I want to get feedback to improve this or move in a completely different directions. 

 In this approach, we have a function `combine_plots` that accepts a list of tuple. The first element of the tuple are ArviZ plotting functions, and the second elementis  optional a dictionary of kwargs

So for instance we can do 

```python
dt = azb.load_arviz_data('centered_eight')

combine_plots(dt, plots=[(azp.plot_dist, {"kind": "kde",}),
                         (azp.plot_dist, {"kind": "ecdf",}),
                         (azp.plot_dist, {"kind": "hist"}),
                        ],
                expanded_dim="column",
                group="posterior",
                var_names=["mu", "tau"],                         
                         )
```
![00](https://github.com/user-attachments/assets/d613765d-4605-47fe-acce-d77f3e0d1214)


or along rows

```python
combine_plots(dt, plots=[(azp.plot_dist, {"kind": "kde",}),
                         (azp.plot_dist, {"kind": "ecdf",}),
                         (azp.plot_dist, {"kind": "hist"}),
                        ],
                expanded_dim="rows",
```

![01](https://github.com/user-attachments/assets/1bddf441-cbf1-4eff-9d8f-e757a3ac5eac)


or 


```python
combine_plots(dt, plots=[(azp.plot_ppc_pit, {}),
                         (azp.plot_ppc_rootogram, {}),
                        ],
                var_names="home_points",
                group="posterior_predictive",         
                         )          
``` 

![02](https://github.com/user-attachments/assets/b0578aba-d64c-4c96-91c2-d5000bb4aa9c)
                 
And it does not currently work for some other plots

```python
dt = azb.load_arviz_data("rugby")
combine_plots(dt, plots=[
                         (azp.plot_ess_evolution, {}),
                         (azp.plot_dist, {}),
                         (azp.plot_rank, {}),
],
                var_names="mu",
                         )
```
            
![03](https://github.com/user-attachments/assets/62a9b483-0372-4e42-96c2-510f1e27231d)


<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--207.org.readthedocs.build/en/207/

<!-- readthedocs-preview arviz-plots end -->