### PR TITLE
fixes shared x property for appropriate plots ( like rank plot, trace plot etc )

### DIFF
--- a/src/arviz_plots/backend/plotly/__init__.py
+++ b/src/arviz_plots/backend/plotly/__init__.py
@@ -26,6 +26,28 @@ unset = UnsetDefault()
 pat = re.compile(r"^(row|col)\s?:")
 
 
+def is_shared_x(fig):
+    """Check if all x-axes are shared in the given figure."""
+    x_axes = [fig.layout[key] for key in fig.layout if key.startswith("xaxis")]
+
+    if len(x_axes) <= 1:
+        return True
+
+    master_axis = None
+    for axis in x_axes:
+        if hasattr(axis, "matches"):
+            if master_axis is None:
+                master_axis = axis.matches
+            elif axis.matches is not None and axis.matches != master_axis:
+                return False
+        else:
+            if master_axis is not None and f"xaxis{axis.anchor[1:]}" != master_axis:
+                return False
+    if master_axis is None:
+        return False
+    return True
+
+
 def apply_square_root_scale(plotly_plot):
     """Apply a square root scale to the y-axis of a PlotlyPlot."""
     chart = plotly_plot.chart
@@ -613,6 +635,13 @@ def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
 def xlabel(string, target, *, size=unset, color=unset, **artist_kws):
     """Interface to plotly for adding a label to the y axis."""
     kwargs = {"size": size, "color": color}
+
+    # Check if the x axis is shared
+    is_shared_x_val = is_shared_x(target.chart)
+    row, _ = target.chart._get_subplot_rows_columns()  # pylint: disable=protected-access
+    if is_shared_x_val and target.row != row[len(row) - 1]:
+        return
+
     target.update_xaxes(
         title={"text": str_to_plotly_html(string), "font": _filter_kwargs(kwargs, artist_kws)}
     )

--- a/src/arviz_plots/plots/ecdf_plot.py
+++ b/src/arviz_plots/plots/ecdf_plot.py
@@ -173,6 +173,7 @@ def plot_ecdf_pit(
 
     if plot_collection is None:
         pc_kwargs["plot_grid_kws"] = pc_kwargs.get("plot_grid_kws", {}).copy()
+        pc_kwargs["plot_grid_kws"].setdefault("sharex", True)
         pc_kwargs["aes"] = pc_kwargs.get("aes", {}).copy()
         pc_kwargs.setdefault("col_wrap", 5)
         pc_kwargs.setdefault(

--- a/src/arviz_plots/plots/ess_plot.py
+++ b/src/arviz_plots/plots/ess_plot.py
@@ -277,7 +277,7 @@ def plot_ess(
         aux_dim_list = [dim for dim in pc_kwargs["cols"] if dim != "__variable__"]
 
         pc_kwargs = set_figure_layout(pc_kwargs, plot_bknd, distribution)
-
+        pc_kwargs["plot_grid_kws"].setdefault("sharex", True)
         plot_collection = PlotCollection.wrap(
             distribution,
             backend=backend,

--- a/src/arviz_plots/plots/evolution_plot.py
+++ b/src/arviz_plots/plots/evolution_plot.py
@@ -247,7 +247,7 @@ def plot_ess_evolution(
         )
 
         pc_kwargs = set_figure_layout(pc_kwargs, plot_bknd, distribution)
-
+        pc_kwargs["plot_grid_kws"].setdefault("sharex", True)
         plot_collection = PlotCollection.wrap(
             distribution,
             backend=backend,

--- a/src/arviz_plots/plots/ppc_pit_plot.py
+++ b/src/arviz_plots/plots/ppc_pit_plot.py
@@ -209,6 +209,7 @@ def plot_ppc_pit(
 
     if plot_collection is None:
         pc_kwargs["plot_grid_kws"] = pc_kwargs.get("plot_grid_kws", {}).copy()
+        pc_kwargs["plot_grid_kws"].setdefault("sharex", True)
         pc_kwargs["aes"] = pc_kwargs.get("aes", {}).copy()
         pc_kwargs.setdefault("cols", "__variable__")
         pc_kwargs.setdefault("rows", None)

--- a/src/arviz_plots/plots/rank_plot.py
+++ b/src/arviz_plots/plots/rank_plot.py
@@ -167,7 +167,7 @@ def plot_rank(
             pc_kwargs["aes"].setdefault("overlay", ["chain"])
 
         pc_kwargs = set_figure_layout(pc_kwargs, plot_bknd, dt_ecdf_ranks)
-
+        pc_kwargs["plot_grid_kws"].setdefault("sharex", True)
         plot_collection = PlotCollection.wrap(
             dt_ecdf_ranks,
             backend=backend,
@@ -219,7 +219,6 @@ def plot_rank(
             xlabel_kwargs.setdefault("color", "black")
 
         xlabel_kwargs.setdefault("text", "Fractional ranks")
-
         plot_collection.map(
             labelled_x,
             "xlabel",

--- a/src/arviz_plots/plots/trace_plot.py
+++ b/src/arviz_plots/plots/trace_plot.py
@@ -141,6 +141,7 @@ def plot_trace(
             pc_kwargs["plot_grid_kws"]["figsize"] = figsize
             pc_kwargs["plot_grid_kws"]["figsize_units"] = "dots"
         aux_dim_list = [dim for dim in pc_kwargs["cols"] if dim != "__variable__"]
+        pc_kwargs["plot_grid_kws"].setdefault("sharex", True)
         plot_collection = PlotCollection.wrap(
             distribution,
             backend=backend,


### PR DESCRIPTION
This PR sets default value of `sharex` as True for plots like rank plot, trace plot, ess plot etc. ( the plots which share x axis ). 
It first sets default value as True then it sets x label accordingly. If sharex has been set as True then it sets x axis label for the subplots in last row only. 

Also no direct way was available to check if Shared x is true or not, so wrote a work around function `is_shared_x` which takes chart and checks for shared x value.

Few Examples of fixes:

Before 1:

![image](https://github.com/user-attachments/assets/269d1fc6-6a16-488b-9ea6-91fd66f384bb)

After 1:

![image](https://github.com/user-attachments/assets/1f35acdf-8787-4005-ba54-a21adbd77909)

Before 2:

![image](https://github.com/user-attachments/assets/3b9b7d1d-568b-400a-aea3-b450d91c92f4)

After 2:

![image](https://github.com/user-attachments/assets/bf95869d-c42b-4c63-be31-0c3bd4de4aa6)

Before 3:

![image](https://github.com/user-attachments/assets/ee4eb397-bc0a-48f9-a3e1-394a3f973c9f)

After 3:

![image](https://github.com/user-attachments/assets/7d56f4ca-a35f-4448-a48b-e8249a446bd6)


Also this PR solves conflicts due to x labels ( #204 ) of plots which share their x axes.

<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--208.org.readthedocs.build/en/208/

<!-- readthedocs-preview arviz-plots end -->