### PR TITLE
Allow prior predictive checks when observed_data group is not present

### DIFF
--- a/src/arviz_plots/plots/ppc_dist_plot.py
+++ b/src/arviz_plots/plots/ppc_dist_plot.py
@@ -94,14 +94,15 @@ def plot_ppc_dist(
         Valid keys are:
 
         * predictive_density -> passed to a function that depends on the `kind` argument.
-        * observed_density -> passed to a function that depends on the `kind` argument. Defaults to
-        False if group is "prior_predictive".
+        * observed_density -> passed to a function that depends on the `kind` argument.
         * `kind="kde"` -> passed to :func:`~arviz_plots.visuals.line_xy`
         * `kind="ecdf"` -> passed to :func:`~arviz_plots.visuals.ecdf_line`
         * `kind="hist"` -> passed to :func: `~arviz_plots.visuals.hist`
-
         * title -> passed to :func:`~arviz_plots.visuals.labelled_title`
         * remove_axis -> not passed anywhere, can only be ``False`` to skip calling this function
+
+        observed_density defaults to False, no observed data is plotted, if group is
+        "prior_predictive". Pass an (empty) mapping to plot the observed data.
 
     stats_kwargs : mapping, optional
         Valid keys are:

--- a/src/arviz_plots/plots/ppc_rootogram_plot.py
+++ b/src/arviz_plots/plots/ppc_rootogram_plot.py
@@ -86,13 +86,15 @@ def plot_ppc_rootogram(
         Valid keys are:
 
         * predictive_markers -> passed to :func:`~arviz_plots.visuals.scatter_xy`
-        * observed_markers -> passed to :func:`~arviz_plots.visuals.scatter_xy`. Defaults to
-            False if group is "prior_predictive" and {} otherwise.
+        * observed_markers -> passed to :func:`~arviz_plots.visuals.scatter_xy`.
         * ci -> passed to :func:`~arviz_plots.visuals.ci_line_y`
         * xlabel -> passed to :func:`~arviz_plots.visuals.labelled_x`
         * ylabel -> passed to :func:`~arviz_plots.visuals.labelled_y`
         * grid -> passed to :func:`~arviz_plots.visuals.grid`
         * title -> passed to :func:`~arviz_plots.visuals.labelled_title`
+
+        observed_markers defaults to False, no observed data is plotted, if group is
+        "prior_predictive". Pass an (empty) mapping to plot the observed data.
 
     pc_kwargs : mapping
         Passed to :class:`arviz_plots.PlotCollection.grid`

--- a/src/arviz_plots/plots/ppc_tstat.py
+++ b/src/arviz_plots/plots/ppc_tstat.py
@@ -91,8 +91,7 @@ def plot_ppc_tstat(
           * "ecdf" -> passed to :func:`~arviz_plots.visuals.ecdf_line`
           * "hist" -> passed to :func: `~arviz_plots.visuals.hist`
 
-        * observed_tstat -> passed to :func:`~arviz_plots.visuals.scatter_x`. Defaults to
-        False if group is "prior_predictive".
+        * observed_tstat -> passed to :func:`~arviz_plots.visuals.scatter_x`.
         * credible_interval -> passed to :func:`~arviz_plots.visuals.line_x`. Defaults to False.
         * point_estimate -> passed to :func:`~arviz_plots.visuals.scatter_x`. Defaults to False.
         * point_estimate_text -> passed to :func:`~arviz_plots.visuals.point_estimate_text`.
@@ -100,6 +99,9 @@ def plot_ppc_tstat(
         * title -> passed to :func:`~arviz_plots.visuals.labelled_title`
         * rug -> passed to :func:`~arviz_plots.visuals.scatter_x`. Defaults to False.
         * remove_axis -> not passed anywhere, can only be ``False`` to skip calling this function
+
+        observed_tstat defaults to False, no observed data is plotted, if group is
+        "prior_predictive". Pass an (empty) mapping to plot the observed tstats.
 
     stats_kwargs : mapping, optional
         Valid keys are:


### PR DESCRIPTION
Additionally, this defaults  `plot_ppc_tstat` to not plotting the observed t-statistics if group is "prior_predictive" in line with the behaviour of `plot_ppc_dist` and `plot_ppc_rootogram`.

<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--226.org.readthedocs.build/en/226/

<!-- readthedocs-preview arviz-plots end -->