### PR TITLE
fix bug plot_ppc_dist when passing references and add test

### DIFF
--- a/docs/source/api/helpers.rst
+++ b/docs/source/api/helpers.rst
@@ -1,0 +1,15 @@
+=========================
+Helper plotting functions
+=========================
+
+Helper plotting functions are available at the ``arviz_plots`` top level namespace and
+provide ways to customize plots by adding elements or modifying existing ones.
+
+An introductory guide to the ``plot_...`` functions is also available at :ref:`plots_intro`.
+
+.. currentmodule:: arviz_plots
+
+.. autosummary::
+   :toctree: generated/
+
+   add_reference_lines

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -11,6 +11,5 @@ plots
 helpers
 managers
 visuals
-```
 backend/index
 ```

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -4,13 +4,13 @@
 .. automodule:: arviz_plots
 ```
 
-`arviz_plots` is composed of 4 main modules:
-
 ```{toctree}
 :maxdepth: 1
 
 plots
+helpers
 managers
 visuals
+```
 backend/index
 ```

--- a/docs/source/api/plots.rst
+++ b/docs/source/api/plots.rst
@@ -17,7 +17,6 @@ A complementary introduction and guide to ``plot_...`` functions is available at
 .. autosummary::
    :toctree: generated/
 
-   add_reference_lines
    combine_plots
    plot_autocorr
    plot_bf

--- a/src/arviz_plots/plots/ppc_dist_plot.py
+++ b/src/arviz_plots/plots/ppc_dist_plot.py
@@ -316,11 +316,12 @@ def plot_ppc_dist(
             )
     if references is not None:
         add_reference_lines(
-            plot_collection,
-            aes_map,
-            plot_kwargs,
-            plot_bknd,
-            references,
+            plot_collection=plot_collection,
+            references=references,
+            orientation="vertical",
+            aes_map=aes_map,
+            plot_kwargs=plot_kwargs,
+            backend=backend,
             data_vars=predictive_dist.data_vars,
         )
 

--- a/src/arviz_plots/plots/utils.py
+++ b/src/arviz_plots/plots/utils.py
@@ -199,6 +199,24 @@ def add_reference_lines(
         The backend used for plotting.
     data_vars : list, optional
         A list of data variables to be used for plotting.
+
+    Examples
+    --------
+    Add reference line at value 0.
+
+    .. plot::
+        :context: close-figs
+
+        >>> from arviz_plots import plot_dist, add_reference_lines, style
+        >>> style.use("arviz-variat")
+        >>> from arviz_base import load_arviz_data
+        >>> dt = load_arviz_data('centered_eight')
+        >>> pc = plot_dist(
+        >>>     dt,
+        >>>     kind="ecdf",
+        >>>     var_names=["mu"],
+        >>> )
+        >>> add_reference_lines(pc, references=0)
     """
     if backend is None:
         backend = plot_collection.backend

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -439,8 +439,9 @@ class TestPlots:  # pylint: disable=too-many-public-methods
 
     # omitting hist for the moment as I get [hist-none] - ValueError: artist_kws not empty
     @pytest.mark.parametrize("kind", ["kde", "ecdf"])
-    def test_plot_ppc_dist(self, datatree, kind, backend):
-        pc = plot_ppc_dist(datatree, kind=kind, backend=backend)
+    @pytest.mark.parametrize("references", [None, (0, 10)])
+    def test_plot_ppc_dist(self, datatree, kind, references, backend):
+        pc = plot_ppc_dist(datatree, kind=kind, references=references, backend=backend)
         assert "chart" in pc.viz.data_vars
         assert pc.aes["y"]
         assert kind in pc.viz["y"]


### PR DESCRIPTION
In #223, I forgot to update `plot_ppc_dist` after generalising the `add_reference_lines` function.

<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--228.org.readthedocs.build/en/228/

<!-- readthedocs-preview arviz-plots end -->