### PR TITLE
Make example less cluncky

### DIFF
--- a/docs/source/gallery/mixed/02_plot_forest_ess.py
+++ b/docs/source/gallery/mixed/02_plot_forest_ess.py
@@ -9,8 +9,6 @@ Multiple panel visualization with a forest plot and ESS information
 API Documentation: {func}`~arviz_plots.plot_forest`
 :::
 """
-from importlib import import_module
-
 import arviz_stats  # make azstats accessor available
 from arviz_base import load_arviz_data
 
@@ -18,18 +16,22 @@ import arviz_plots as azp
 
 azp.style.use("arviz-variat")
 
-backend="none"  # change to preferred backend
-plot_bknd = import_module(f".backend.{backend}", package="arviz_plots")
-color = plot_bknd.get_default_aes("color", 1, {})[0]
-
 centered = load_arviz_data("centered_eight")
-c_aux = centered["posterior"].dataset.expand_dims(
-    column=3
-).assign_coords(column=["labels", "forest", "ess"])
-pc = azp.plot_forest(c_aux, combined=True, backend=backend)
+
+c_aux = (centered["posterior"]
+         .dataset.expand_dims(column=3)
+         .assign_coords(column=["labels", "forest", "ess"]))
+
+pc = azp.plot_forest(c_aux,
+                     combined=True,
+                     backend="none",  # change to preferred backend
+                     )
+
 pc.map(
-    azp.visuals.scatter_x, "ess",
+    azp.visuals.scatter_x,
+    "ess",
     data=centered.posterior.ds.azstats.ess(),
-    coords={"column": "ess"}, color=color
+    coords={"column": "ess"},
+    color="#36acc6",
 )
 pc.show()

--- a/docs/source/gallery/mixed/02_plot_forest_ess.py
+++ b/docs/source/gallery/mixed/02_plot_forest_ess.py
@@ -32,6 +32,6 @@ pc.map(
     "ess",
     data=centered.posterior.ds.azstats.ess(),
     coords={"column": "ess"},
-    color="#36acc6",
+    color="gray",
 )
 pc.show()

--- a/docs/source/gallery/mixed/02_plot_forest_ess.py
+++ b/docs/source/gallery/mixed/02_plot_forest_ess.py
@@ -18,14 +18,17 @@ azp.style.use("arviz-variat")
 
 centered = load_arviz_data("centered_eight")
 
-c_aux = (centered["posterior"]
-         .dataset.expand_dims(column=3)
-         .assign_coords(column=["labels", "forest", "ess"]))
+c_aux = (
+    centered["posterior"]
+    .dataset.expand_dims(column=3)
+    .assign_coords(column=["labels", "forest", "ess"])
+)
 
-pc = azp.plot_forest(c_aux,
-                     combined=True,
-                     backend="none",  # change to preferred backend
-                     )
+pc = azp.plot_forest(
+    c_aux,
+    combined=True,
+    backend="none",  # change to preferred backend
+)
 
 pc.map(
     azp.visuals.scatter_x,

--- a/docs/source/gallery/predictive_checks/99_plot_forest_pp_obs.py
+++ b/docs/source/gallery/predictive_checks/99_plot_forest_pp_obs.py
@@ -21,9 +21,9 @@ pc = azp.plot_forest(
     group="posterior_predictive",
     combined=True,
     labels=["obs_dim_0"],
-    backend = "none",  # change to preferred backend
-
+    backend="bokeh",  # change to preferred backend
 )
+
 pc.map(
     azp.visuals.scatter_x,
     "observations",

--- a/docs/source/gallery/predictive_checks/99_plot_forest_pp_obs.py
+++ b/docs/source/gallery/predictive_checks/99_plot_forest_pp_obs.py
@@ -9,17 +9,11 @@ Overlay of forest plot for the posterior predictive samples and the actual obser
 API Documentation: {func}`~arviz_plots.plot_forest`
 :::
 """
-from importlib import import_module
-
 from arviz_base import load_arviz_data
 
 import arviz_plots as azp
 
 azp.style.use("arviz-variat")
-
-backend="none"  # change to preferred backend
-plot_bknd = import_module(f".backend.{backend}", package="arviz_plots")
-color = plot_bknd.get_default_aes("color", 3, {})[-1]
 
 idata = load_arviz_data("non_centered_eight")
 pc = azp.plot_forest(
@@ -27,15 +21,22 @@ pc = azp.plot_forest(
     group="posterior_predictive",
     combined=True,
     labels=["obs_dim_0"],
-    backend=backend,
+    backend = "none",  # change to preferred backend
+
 )
 pc.map(
     azp.visuals.scatter_x,
     "observations",
     data=idata.observed_data.ds,
     coords={"column": "forest"},
-    color=color,
+    color="gray",
 )
-target = pc.viz["plot"].sel(column="forest").item()
-plot_bknd.xlabel("Observations", target)
+
+pc.map(
+    azp.visuals.labelled_x,
+    "xlabel",
+    coords={"column": "forest"},
+    text="Observations",
+    ignore_aes="y",  # we can omit this in matplotlib, but not bokeh, plotly
+)
 pc.show()

--- a/docs/source/gallery/predictive_checks/99_plot_forest_pp_obs.py
+++ b/docs/source/gallery/predictive_checks/99_plot_forest_pp_obs.py
@@ -37,6 +37,6 @@ pc.map(
     "xlabel",
     coords={"column": "forest"},
     text="Observations",
-    ignore_aes="y",  # we can omit this in matplotlib, but not bokeh, plotly
+    ignore_aes="y",
 )
 pc.show()


### PR DESCRIPTION
I think these lines do not reflect patterns we want to encourage.  So I am removing them.

```python
plot_bknd = import_module(f".backend.{backend}", package="arviz_plots")
color = plot_bknd.get_default_aes("color", 1, {})[0]
```

```python
target = pc.viz["plot"].sel(column="forest").item()
plot_bknd.xlabel("Observations", target)
```



<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--234.org.readthedocs.build/en/234/

<!-- readthedocs-preview arviz-plots end -->