### PR TITLE
use scalar prob for quantile/tail ess

### DIFF
--- a/src/arviz_plots/plots/convergence_dist_plot.py
+++ b/src/arviz_plots/plots/convergence_dist_plot.py
@@ -287,6 +287,7 @@ def _compute_diagnostics(dt, diagnostics, sample_dims, grouped):
             method = diagnostic.split("_", 1)[1].split("(", 1)[0]
             if method in {"tail", "quantile", "local"} and "(" in diagnostic:
                 prob = [float(p) for p in diagnostic.split("(", 1)[1].rstrip(")").split(", ")]
+                prob = prob[0] if len(prob) == 1 else prob
 
             diagnostic_dt = dt.azstats.ess(method=method, prob=prob, dims=sample_dims)
             if grouped:


### PR DESCRIPTION
I added a call in ess to the prob validating function in arviz-stats in a recent PR.
For local ess it does a loop over the given probabilities and validates each but for
tail/quantile it is called directly. The validator doesn't allow single element list/array-like
and there were some cases in plot_convergence_dist` that could use that, this should make
sure a scalar is used. Being a single case where this happened I thought it was better to fix
here than to extend the validator in arviz-stats.

Edit: forgot to commit the sequence side of prob validation, https://github.com/arviz-devs/arviz-stats/pull/109 combined with this should fix it

<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--240.org.readthedocs.build/en/240/

<!-- readthedocs-preview arviz-plots end -->