### PR TITLE
Update ref_dim in add_reference_lines

### DIFF
--- a/src/arviz_plots/plots/utils.py
+++ b/src/arviz_plots/plots/utils.py
@@ -255,7 +255,9 @@ def add_reference_lines(
 
     plot_func = vline if orientation == "vertical" else hline
 
-    ref_ds = references_to_dataset(references, plot_collection.data, sample_dims=sample_dims)
+    ref_ds = references_to_dataset(
+        references, plot_collection.data, sample_dims=sample_dims, ref_dim=ref_dim
+    )
     requested_aes = (
         set(aes_map["ref_line"]).union(aes_map["ref_text"]).difference(plot_collection.aes_set)
     )

--- a/src/arviz_plots/plots/utils.py
+++ b/src/arviz_plots/plots/utils.py
@@ -175,7 +175,7 @@ def add_reference_lines(
     aes_map=None,
     plot_kwargs=None,
     sample_dims=None,
-    ref_dim="ref_line_dim",
+    ref_dim="ref_dim",
     **kwargs,
 ):
     """Add reference lines.
@@ -199,7 +199,7 @@ def add_reference_lines(
         The default is to use an "overlay" aesthetic for all elements.
 
         It is possible to request aesthetics without mappings defined in the
-        provided `plot_collection`. In those cases, a mapping of "ref_line_dim" to the requested
+        provided `plot_collection`. In those cases, a mapping of "ref_dim" to the requested
         aesthetic will be automatically added.
     plot_kwargs : mapping of {str : mapping or False}, optional
         Valid keys are:
@@ -211,6 +211,9 @@ def add_reference_lines(
     sample_dims : list, optional
         Dimensions to reduce unless mapped to an aesthetic.
         Defaults to ``rcParams["data.sample_dims"]``
+    ref_dim : str, optional
+        Specifies the name of the reference dimension for reference values.
+        Defaults to "ref_dim".
     **kwargs : mapping of {str : sequence}, optional
         Mapping of aesthetic keys to the values to be used in their mapping.
         See :func:`~arviz_plots.PlotCollection.generate_aes_dt` for more details.

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -564,20 +564,20 @@ class TestPlots:  # pylint: disable=too-many-public-methods
         pc = plot_dist(datatree, backend=backend)
         add_reference_lines(pc, 0)
         assert "ref_line" in pc.viz["mu"]
-        assert "ref_line_dim" not in pc.viz["mu"]["ref_line"].dims
+        assert "ref_dim" not in pc.viz["mu"]["ref_line"].dims
 
     def test_add_references_array(self, datatree, backend):
         pc = plot_dist(datatree, backend=backend)
         add_reference_lines(pc, [0, 1])
         assert "ref_line" in pc.viz["mu"]
-        assert "ref_line_dim" in pc.viz["mu"]["ref_line"].dims
+        assert "ref_dim" in pc.viz["mu"]["ref_line"].dims
 
     def test_add_references_dict(self, datatree, backend):
         pc = plot_dist(datatree, backend=backend)
         add_reference_lines(pc, {"mu": [0, 1]})
         assert "ref_line" in pc.viz["mu"]
         assert "ref_line" not in pc.viz["theta"]
-        assert "ref_line_dim" in pc.viz["mu"]["ref_line"].dims
+        assert "ref_dim" in pc.viz["mu"]["ref_line"].dims
 
     def test_add_references_ds(self, datatree, backend):
         pc = plot_dist(datatree, backend=backend)
@@ -594,6 +594,6 @@ class TestPlots:  # pylint: disable=too-many-public-methods
         pc = plot_dist(datatree, backend=backend)
         add_reference_lines(pc, [0, 1], aes_map={"ref_line": ["color"]})
         assert "ref_line" in pc.viz["mu"]
-        assert "ref_line_dim" in pc.viz["mu"]["ref_line"].dims
+        assert "ref_dim" in pc.viz["mu"]["ref_line"].dims
         assert "color" in pc.aes["mu"]
-        assert "ref_line_dim" in pc.aes["mu"]["color"].dims
+        assert "ref_dim" in pc.aes["mu"]["color"].dims


### PR DESCRIPTION
- Pass ref_dim to references_to_dataset

With the references_to_dataset now updated in this [PR](https://github.com/arviz-devs/arviz-base/pull/53), making the fix to support it here.

<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--254.org.readthedocs.build/en/254/

<!-- readthedocs-preview arviz-plots end -->