### PR TITLE
Correct a typo: instatiates -> instantiates

### DIFF
--- a/src/arviz_plots/plot_collection.py
+++ b/src/arviz_plots/plot_collection.py
@@ -163,7 +163,7 @@ def _get_aes_dict_from_dt(aes_dt):
 class PlotCollection:
     """Low level base class for plotting with xarray Datasets.
 
-    This class instatiates a chart with multiple plots in it and provides methods to loop
+    This class instantiates a chart with multiple plots in it and provides methods to loop
     over these plots and the provided data syncing each plot and data subset to
     user given aesthetics.
 


### PR DESCRIPTION
Correct a typo: instatiates -> instantiates

<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--255.org.readthedocs.build/en/255/

<!-- readthedocs-preview arviz-plots end -->