### PR TITLE
Revise a cross-ref in docs.md

### DIFF
--- a/docs/source/contributing/docs.md
+++ b/docs/source/contributing/docs.md
@@ -53,7 +53,7 @@ a short description of the example and a seealso directive using MyST syntax.
 
 The code part should import arviz-plots as `azp`. Later on, it set `backend="none"`
 explicitly when calling the plotting functions and
-store the generated :class:`~arviz_plots.PlotCollection` as the `pc` variable
+store the generated {class}`~arviz_plots.PlotCollection` as the `pc` variable
 so the example can finish with `pc.show()`.
 
 Here is an example that can be used as template:


### PR DESCRIPTION
Revise a cross-ref in docs.md.

Incorrect:
:class:`~arviz_plots.PlotCollection`

Correct:
{class}`~arviz_plots.PlotCollection`

<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--260.org.readthedocs.build/en/260/

<!-- readthedocs-preview arviz-plots end -->