### PR TITLE
rename add_reference_lines and reference_bands

### DIFF
--- a/docs/source/api/helpers.rst
+++ b/docs/source/api/helpers.rst
@@ -12,8 +12,8 @@ An introductory guide to the ``plot_...`` functions is also available at :ref:`p
 .. autosummary::
    :toctree: generated/
 
-   add_reference_bands
-   add_reference_lines
+   add_bands
+   add_lines
 
 Style
 ...............

--- a/docs/source/gallery/utils/00_add_reference_lines.py
+++ b/docs/source/gallery/utils/00_add_reference_lines.py
@@ -1,12 +1,12 @@
 """
-# Add Reference Lines
+# Add Lines
 
-Draw reference lines on plots to highlight specific thresholds, targets, or important values.
+Draw lines on plots to highlight specific thresholds, targets, or important values.
 
 ---
 
 :::{seealso}
-API Documentation: {func}`~arviz_plots.add_reference_lines`
+API Documentation: {func}`~arviz_plots.add_lines`
 :::
 """
 
@@ -23,9 +23,9 @@ pc = azp.plot_dist(
     kind="ecdf",
     backend="none",   # change to preferred backend
 )
-pc = azp.add_reference_lines(
+pc = azp.add_lines(
     pc,
-    references=ref_ds,
+    values=ref_ds,
     ref_dim="quantile",
     aes_map={"ref_line": ["color"]},
     color=["black", "gray", "gray"]

--- a/docs/source/gallery/utils/01_add_reference_bands.py
+++ b/docs/source/gallery/utils/01_add_reference_bands.py
@@ -26,8 +26,7 @@ pc.coords = {"column": "forest"}
 pc = azp.add_bands(
     pc,
     values=rope,
-    aes_map={"ref_band": ["color"]},
-    color=["#f66d7f"]
+    plot_kwargs={"ref_band":{"color": "#f66d7f"}},
 )
 
 pc.show()

--- a/docs/source/gallery/utils/01_add_reference_bands.py
+++ b/docs/source/gallery/utils/01_add_reference_bands.py
@@ -1,12 +1,12 @@
 """
 # Add Reference Bands
 
-Draw reference bands on plots to highlight specific regions.
+Draw reference bands to highlight specific regions.
 
 ---
 
 :::{seealso}
-API Documentation: {func}`~arviz_plots.add_reference_bands`
+API Documentation: {func}`~arviz_plots.add_bands`
 :::
 """
 
@@ -17,18 +17,17 @@ import arviz_plots as azp
 azp.style.use("arviz-variat")
 
 data = load_arviz_data("centered_eight")
-references = [(0, 5), (5, 20)]
-pc = azp.plot_dist(
+rope = [(-1, 1)]
+pc = azp.plot_forest(
     data,
-    kind="ecdf",
     backend="none",   # change to preferred backend
 )
 
-pc = azp.add_reference_bands(
+pc = azp.add_bands(
     pc,
-    references=references,
+    values=rope,
     aes_map={"ref_band": ["color"]},
-    color=["black", "gray"]
+    color=["#f66d7f"]
 )
 
 pc.show()

--- a/docs/source/gallery/utils/01_add_reference_bands.py
+++ b/docs/source/gallery/utils/01_add_reference_bands.py
@@ -22,7 +22,7 @@ pc = azp.plot_forest(
     data,
     backend="none",   # change to preferred backend
 )
-
+pc.coords = {"column": "forest"}
 pc = azp.add_bands(
     pc,
     values=rope,

--- a/src/arviz_plots/plots/__init__.py
+++ b/src/arviz_plots/plots/__init__.py
@@ -26,7 +26,7 @@ from .rank_plot import plot_rank
 from .ridge_plot import plot_ridge
 from .trace_dist_plot import plot_trace_dist
 from .trace_plot import plot_trace
-from .utils import add_reference_bands, add_reference_lines
+from .utils import add_bands, add_lines
 
 __all__ = [
     "combine_plots",
@@ -55,6 +55,6 @@ __all__ = [
     "plot_ppc_tstat",
     "plot_psense_dist",
     "plot_psense_quantities",
-    "add_reference_lines",
-    "add_reference_bands",
+    "add_lines",
+    "add_bands",
 ]

--- a/src/arviz_plots/plots/bf_plot.py
+++ b/src/arviz_plots/plots/bf_plot.py
@@ -6,7 +6,7 @@ import xarray as xr
 from arviz_stats.bayes_factor import bayes_factor
 
 from arviz_plots.plots.prior_posterior_plot import plot_prior_posterior
-from arviz_plots.plots.utils import add_reference_lines, filter_aes
+from arviz_plots.plots.utils import add_lines, filter_aes
 
 
 def plot_bf(
@@ -143,7 +143,7 @@ def plot_bf(
             ref_line_kwargs.setdefault("color", "black")
         if "alpha" not in ref_aes:
             ref_line_kwargs.setdefault("alpha", 0.5)
-        add_reference_lines(
+        add_lines(
             plot_collection, ref_val, aes_map=aes_map, plot_kwargs={"ref_line": ref_line_kwargs}
         )
 

--- a/src/arviz_plots/plots/utils.py
+++ b/src/arviz_plots/plots/utils.py
@@ -239,7 +239,7 @@ def add_lines(
         >>>     kind="ecdf",
         >>>     var_names=["mu"],
         >>> )
-        >>> add_lines(pc, references=[0, 5])
+        >>> add_lines(pc, values=[0, 5])
     """
     if plot_kwargs is None:
         plot_kwargs = {}

--- a/src/arviz_plots/plots/utils.py
+++ b/src/arviz_plots/plots/utils.py
@@ -168,9 +168,9 @@ def set_grid_layout(pc_kwargs, plot_bknd, ds, num_rows=None, num_cols=None):
     return pc_kwargs
 
 
-def add_reference_lines(
+def add_lines(
     plot_collection,
-    references,
+    values,
     orientation="vertical",
     aes_map=None,
     plot_kwargs=None,
@@ -178,20 +178,19 @@ def add_reference_lines(
     ref_dim="ref_dim",
     **kwargs,
 ):
-    """Add reference lines.
+    """Add lines.
 
-    This function adds lines to a plot collection based on the provided
-    references. It supports both vertical and horizontal lines, depending on the
-    specified orientation.
+    This function adds lines to a plot collection based on the provided values.
+    It supports both vertical and horizontal lines, depending on the specified orientation.
 
     Parameters
     ----------
     plot_collection : PlotCollection
-        Plot collection to which the reference lines will be added.
-    references : int, float, tuple, list or dict
-        Reference values to be plotted as lines.
+        Plot collection to which the lines will be added.
+    values : int, float, tuple, list or dict
+        Positions for the lines.
     orientation : str, default "vertical"
-        The orientation of the reference lines, either "vertical" or "horizontal".
+        The orientation of the lines, either "vertical" or "horizontal".
     aes_map : mapping of {str : sequence of str}, optional
         Mapping of artists to aesthetics that should use their mapping in `plot_collection`
         when plotted. Valid keys are the same as for `plot_kwargs`.
@@ -210,10 +209,10 @@ def add_reference_lines(
 
     sample_dims : list, optional
         Dimensions that should not be added to the Dataset generated from
-        `refereces` via :func:`arviz_base.references_to_dataset`.
+        `values` via :func:`arviz_base.references_to_dataset`.
         Defaults to all dimensions in ``plot_collection.data`` that are not ``facet_dims``
     ref_dim : str, optional
-        Specifies the name of the reference dimension for reference values.
+        Specifies the name of the dimension for the line values.
         Defaults to "ref_dim".
     **kwargs : mapping of {str : sequence}, optional
         Mapping of aesthetic keys to the values to be used in their mapping.
@@ -222,16 +221,16 @@ def add_reference_lines(
     Returns
     -------
     plot_collection : PlotCollection
-        Plot collection with the reference lines added.
+        Plot collection with the lines added.
 
     Examples
     --------
-    Add reference lines at values 0 and 5 for all variables.
+    Add lines at values 0 and 5 for all variables.
 
     .. plot::
         :context: close-figs
 
-        >>> from arviz_plots import plot_dist, add_reference_lines, style
+        >>> from arviz_plots import plot_dist, add_lines, style
         >>> style.use("arviz-variat")
         >>> from arviz_base import load_arviz_data
         >>> dt = load_arviz_data('centered_eight')
@@ -240,7 +239,7 @@ def add_reference_lines(
         >>>     kind="ecdf",
         >>>     var_names=["mu"],
         >>> )
-        >>> add_reference_lines(pc, references=[0, 5])
+        >>> add_lines(pc, references=[0, 5])
     """
     if plot_kwargs is None:
         plot_kwargs = {}
@@ -260,7 +259,7 @@ def add_reference_lines(
     plot_func = vline if orientation == "vertical" else hline
 
     ref_ds = references_to_dataset(
-        references, plot_collection.data, sample_dims=sample_dims, ref_dim=ref_dim
+        values, plot_collection.data, sample_dims=sample_dims, ref_dim=ref_dim
     )
     requested_aes = (
         set(aes_map["ref_line"]).union(aes_map["ref_text"]).difference(plot_collection.aes_set)
@@ -297,9 +296,9 @@ def add_reference_lines(
     return plot_collection
 
 
-def add_reference_bands(
+def add_bands(
     plot_collection,
-    references,
+    values,
     orientation="vertical",
     aes_map=None,
     plot_kwargs=None,
@@ -307,20 +306,20 @@ def add_reference_bands(
     ref_dim=None,
     **kwargs,
 ):
-    """Add reference bands.
+    """Add bands.
 
-    This function adds lines to a plot collection based on the provided
-    references. It supports both vertical and horizontal lines, depending on the
+    This function adds bands (shared areas) to a plot collection based on the provided
+    values. It supports both vertical and horizontal bands, depending on the
     specified orientation.
 
     Parameters
     ----------
     plot_collection : PlotCollection
-        Plot collection to which the reference lines will be added.
-    references : tuple, list or dict
-        Reference values to be plotted as bands/shaded regions.
+        Plot collection to which the bands will be added.
+    values : tuple, list or dict
+        Start and end values for the bands to be plotted.
     orientation : str, default "vertical"
-        The orientation of the reference lines, either "vertical" or "horizontal".
+        The orientation of the bands, either "vertical" or "horizontal".
     aes_map : mapping of {str : sequence of str}, optional
         Mapping of artists to aesthetics that should use their mapping in `plot_collection`
         when plotted. Valid keys are the same as for `plot_kwargs`.
@@ -339,11 +338,11 @@ def add_reference_bands(
 
     sample_dims : list, optional
         Dimensions that should not be added to the Dataset generated from
-        `references` via :func:`arviz_base.references_to_dataset`.
+        `values` via :func:`arviz_base.references_to_dataset`.
         Defaults to all dimensions in ``plot_collection.data`` that are not ``facet_dims``
     ref_dim : list, optional
-        List of dimension names that define the axes along which reference values are stored.
-        These dimensions are used to align or compare input data with reference data.
+        List of dimension names that define the axes along which the band values are stored.
+        These dimensions are used to align or compare input data with band data.
         Defaults to ["ref_dim", "band_dim"].
     **kwargs : sequence, optional
         Mapping of aesthetic keys to the values to be used in their mapping.
@@ -352,24 +351,21 @@ def add_reference_bands(
     Returns
     -------
     plot_collection : PlotCollection
-        Plot collection with the reference lines added.
+        Plot collection with the bands added.
 
     Examples
     --------
-    Add reference bands from 0 to 2 and 3 to 5 for all variables.
+    Add two bands for the theta variable, one from -2 to 2 and the other from -5 to 5.
 
     .. plot::
         :context: close-figs
 
-        >>> from arviz_plots import plot_dist, add_reference_bands, style
+        >>> from arviz_plots import plot_dist, add_bands, style
         >>> style.use("arviz-variat")
         >>> from arviz_base import load_arviz_data
         >>> dt = load_arviz_data('centered_eight')
-        >>> pc = plot_dist(
-        >>>     dt,
-        >>>     kind="ecdf"
-        >>> )
-        >>> add_reference_bands(pc, references=[[0, 2], [3, 5]])
+        >>> pc = plot_dist(dt)
+        >>> add_bands(pc, values=[[-2, 2], [-5, 5]])
     """
     if plot_kwargs is None:
         plot_kwargs = {}
@@ -388,7 +384,7 @@ def add_reference_bands(
     plot_func = vspan if orientation == "vertical" else hspan
 
     ref_ds = references_to_dataset(
-        references, plot_collection.data, sample_dims=sample_dims, ref_dim=ref_dim
+        values, plot_collection.data, sample_dims=sample_dims, ref_dim=ref_dim
     )
 
     requested_aes = set(aes_map["ref_band"]).difference(plot_collection.aes_set)

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -7,8 +7,8 @@ from arviz_base import from_dict
 from scipy.stats import halfnorm, norm
 
 from arviz_plots import (
-    add_reference_bands,
-    add_reference_lines,
+    add_bands,
+    add_lines,
     plot_autocorr,
     plot_bf,
     plot_compare,
@@ -584,26 +584,26 @@ class TestPlots:  # pylint: disable=too-many-public-methods
 
     def test_add_references_scalar(self, datatree, backend):
         pc = plot_dist(datatree, backend=backend)
-        add_reference_lines(pc, 0)
+        add_lines(pc, 0)
         assert "mu" in pc.viz["ref_line"]
         assert "ref_dim" not in pc.viz["ref_line"]["mu"].dims
 
     def test_add_references_array(self, datatree, backend):
         pc = plot_dist(datatree, backend=backend)
-        add_reference_lines(pc, [0, 1])
+        add_lines(pc, [0, 1])
         assert "mu" in pc.viz["ref_line"]
         assert "ref_dim" in pc.viz["ref_line"]["mu"].dims
 
     def test_add_references_dict(self, datatree, backend):
         pc = plot_dist(datatree, backend=backend)
-        add_reference_lines(pc, {"mu": [0, 1]})
+        add_lines(pc, {"mu": [0, 1]})
         assert "mu" in pc.viz["ref_line"]
         assert "theta" not in pc.viz["ref_line"]
         assert "ref_dim" in pc.viz["ref_line"]["mu"].dims
 
     def test_add_references_ds(self, datatree, backend):
         pc = plot_dist(datatree, backend=backend)
-        add_reference_lines(
+        add_lines(
             pc,
             datatree.posterior.dataset.quantile((0.1, 0.5, 0.9), dim=["chain", "draw"]),
             ref_dim="quantile",
@@ -615,7 +615,7 @@ class TestPlots:  # pylint: disable=too-many-public-methods
 
     def test_add_references_aes(self, datatree, backend):
         pc = plot_dist(datatree, backend=backend)
-        add_reference_lines(pc, [0, 1], aes_map={"ref_line": ["color"]})
+        add_lines(pc, [0, 1], aes_map={"ref_line": ["color"]})
         assert "mu" in pc.viz["ref_line"].data_vars
         assert "ref_dim" in pc.viz["ref_line"]["mu"].dims
         assert "/color" in pc.aes.groups
@@ -623,20 +623,20 @@ class TestPlots:  # pylint: disable=too-many-public-methods
 
     def test_add_bands_array(self, datatree, backend):
         pc = plot_dist(datatree, backend=backend)
-        add_reference_bands(pc, [(0, 1), (2, 4)])
+        add_bands(pc, [(0, 1), (2, 4)])
         assert "mu" in pc.viz["ref_band"]
         assert "ref_dim" in pc.viz["ref_band"]["mu"].dims
 
     def test_add_bands_dict(self, datatree, backend):
         pc = plot_dist(datatree, backend=backend)
-        add_reference_bands(pc, {"mu": [(0, 1)]})
+        add_bands(pc, {"mu": [(0, 1)]})
         assert "mu" in pc.viz["ref_band"]
         assert "theta" not in pc.viz["ref_band"]
         assert "ref_dim" in pc.viz["ref_band"]["mu"].dims
 
     def test_add_bands_aes(self, datatree, backend):
         pc = plot_dist(datatree, backend=backend)
-        add_reference_bands(pc, [(0, 1), (2, 5)], aes_map={"ref_band": ["color"]})
+        add_bands(pc, [(0, 1), (2, 5)], aes_map={"ref_band": ["color"]})
         assert "mu" in pc.viz["ref_band"].data_vars
         assert "ref_dim" in pc.viz["ref_band"]["mu"].dims
         assert "/color" in pc.aes.groups


### PR DESCRIPTION
This also tweaks the docstrings and examples a little bit. 

If you see the example with `plot_forest`, you will see that the band is incorrectly added to the two columns, not just the `forest` one. Not sure how to fix this.

<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--264.org.readthedocs.build/en/264/

<!-- readthedocs-preview arviz-plots end -->