### PR TITLE
fixes column name from elpd to elpd_loo in cmp_df dataframe

### DIFF
--- a/src/arviz_plots/plots/compare_plot.py
+++ b/src/arviz_plots/plots/compare_plot.py
@@ -68,7 +68,7 @@ def plot_compare(
     """
     # Check if cmp_df contains the required information
     column_index = [c.lower() for c in cmp_df.columns]
-    if "elpd" not in column_index:
+    if "elpd_loo" not in column_index:
         raise ValueError("cmp_df must have been created using the `compare` function from ArviZ.")
 
     # Set default backend
@@ -115,7 +115,7 @@ def plot_compare(
     # Set scale relative to the best model
     if relative_scale:
         cmp_df = cmp_df.copy()
-        cmp_df["elpd"] = cmp_df["elpd"] - cmp_df["elpd"].iloc[0]
+        cmp_df["elpd_loo"] = cmp_df["elpd_loo"] - cmp_df["elpd_loo"].iloc[0]
 
     # Compute positions of yticks
     yticks_pos = list(range(len(cmp_df), 0, -1))
@@ -125,7 +125,9 @@ def plot_compare(
         error_kwargs.setdefault("color", "black")
 
         # Compute values for standard error bars
-        se_list = list(zip((cmp_df["elpd"] - cmp_df["se"]), (cmp_df["elpd"] + cmp_df["se"])))
+        se_list = list(
+            zip((cmp_df["elpd_loo"] - cmp_df["se"]), (cmp_df["elpd_loo"] + cmp_df["se"]))
+        )
 
         for se_vals, ytick in zip(se_list, yticks_pos):
             p_be.line(se_vals, (ytick, ytick), target, **error_kwargs)
@@ -135,7 +137,7 @@ def plot_compare(
         ref_kwargs.setdefault("color", "gray")
         ref_kwargs.setdefault("linestyle", p_be.get_default_aes("linestyle", 2, {})[-1])
         p_be.line(
-            (cmp_df["elpd"].iloc[0], cmp_df["elpd"].iloc[0]),
+            (cmp_df["elpd_loo"].iloc[0], cmp_df["elpd_loo"].iloc[0]),
             (yticks_pos[0], yticks_pos[-1]),
             target,
             **ref_kwargs,
@@ -144,14 +146,14 @@ def plot_compare(
     # Plot ELPD point estimates
     if (pe_kwargs := plot_kwargs.get("point_estimate", {})) is not False:
         pe_kwargs.setdefault("color", "black")
-        p_be.scatter(cmp_df["elpd"], yticks_pos, target, **pe_kwargs)
+        p_be.scatter(cmp_df["elpd_loo"], yticks_pos, target, **pe_kwargs)
 
     # Add shade for statistically undistinguishable models
     if similar_shade and (shade_kwargs := plot_kwargs.get("shade", {})) is not False:
         shade_kwargs.setdefault("color", "black")
         shade_kwargs.setdefault("alpha", 0.1)
 
-        x_0, x_1 = cmp_df["elpd"].iloc[0] - 4, cmp_df["elpd"].iloc[0]
+        x_0, x_1 = cmp_df["elpd_loo"].iloc[0] - 4, cmp_df["elpd_loo"].iloc[0]
 
         padding = (yticks_pos[0] - yticks_pos[-1]) * 0.05
         p_be.fill_between_y(

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -143,7 +143,7 @@ def datatree_sample(seed=31):
 def cmp():
     return pd.DataFrame(
         {
-            "elpd": [-4.5, -14.3, -16.2],
+            "elpd_loo": [-4.5, -14.3, -16.2],
             "p": [2.6, 2.3, 2.1],
             "elpd_diff": [0, 9.7, 11.3],
             "weight": [0.9, 0.1, 0],


### PR DESCRIPTION
In `plot_compare` it expects a dataframe ( result of compare function of arviz ), then it checks for `elpd` column. 

But the latest version of returning dataframe contains `elpd_loo` column instead of `elpd`. So this causes issue while using `plot_compare` 