### PR TITLE
Fixes share axis and share label feature in plotly

### DIFF
--- a/docs/source/api/plots.rst
+++ b/docs/source/api/plots.rst
@@ -29,6 +29,7 @@ A complementary introduction and guide to ``plot_...`` functions is available at
    plot_ess_evolution
    plot_forest
    plot_loo_pit
+   plot_pairs_focus
    plot_ppc_dist
    plot_ppc_pava
    plot_ppc_pit

--- a/docs/source/gallery/distribution/07_plot_pairs_focus_distribution.py
+++ b/docs/source/gallery/distribution/07_plot_pairs_focus_distribution.py
@@ -20,6 +20,7 @@ pc = azp.plot_pairs_focus(
     data,
     var_names=["theta","tau"],
     focus_var="mu",
+    figure_kwargs={"sharex": True},
     backend="none", # change to preferred backend
 )
 pc.show()

--- a/docs/source/gallery/distribution/07_plot_pairs_focus_distribution.py
+++ b/docs/source/gallery/distribution/07_plot_pairs_focus_distribution.py
@@ -1,7 +1,7 @@
 """
-# Pairwise focus distribution without divergence
+# Scatterplot one variable against all others
 
-Pairwise focus distribution of a variable against all other variables in the dataset.
+Plot one variable against other variables in the dataset.
 
 ---
 
@@ -21,6 +21,5 @@ pc = azp.plot_pairs_focus(
     var_names=["theta","tau"],
     focus_var="mu",
     backend="none", # change to preferred backend
-    visuals = {"divergence": False},
 )
 pc.show()

--- a/docs/source/gallery/distribution/07_plot_pairs_focus_distribution.py
+++ b/docs/source/gallery/distribution/07_plot_pairs_focus_distribution.py
@@ -20,7 +20,6 @@ pc = azp.plot_pairs_focus(
     data,
     var_names=["theta","tau"],
     focus_var="mu",
-    figure_kwargs={"sharex":True},
     backend="none", # change to preferred backend
 )
 pc.show()

--- a/docs/source/gallery/distribution/07_plot_pairs_focus_distribution.py
+++ b/docs/source/gallery/distribution/07_plot_pairs_focus_distribution.py
@@ -1,0 +1,26 @@
+"""
+# Pairwise focus distribution without divergence
+
+Pairwise focus distribution of a variable against all other variables in the dataset.
+
+---
+
+:::{seealso}
+API Documentation: {func}`~arviz_plots.plot_pairs_focus`
+:::
+"""
+from arviz_base import load_arviz_data
+
+import arviz_plots as azp
+
+azp.style.use("arviz-variat")
+
+data = load_arviz_data("centered_eight")
+pc = azp.plot_pairs_focus(
+    data,
+    var_names=["theta","tau"],
+    focus_var="mu",
+    backend="none", # change to preferred backend
+    visuals = {"divergence": False},
+)
+pc.show()

--- a/docs/source/gallery/distribution/07_plot_pairs_focus_distribution.py
+++ b/docs/source/gallery/distribution/07_plot_pairs_focus_distribution.py
@@ -20,6 +20,7 @@ pc = azp.plot_pairs_focus(
     data,
     var_names=["theta","tau"],
     focus_var="mu",
+    figure_kwargs={"sharex":True},
     backend="none", # change to preferred backend
 )
 pc.show()

--- a/docs/source/gallery/inference_diagnostics/09_plot_pairs_focus.py
+++ b/docs/source/gallery/inference_diagnostics/09_plot_pairs_focus.py
@@ -1,0 +1,25 @@
+"""
+# Pairwise focus distribution with divergence
+
+Pairwise focus distribution of a variable against all other variables in the dataset.
+
+---
+
+:::{seealso}
+API Documentation: {func}`~arviz_plots.plot_pairs_focus`
+:::
+"""
+from arviz_base import load_arviz_data
+
+import arviz_plots as azp
+
+azp.style.use("arviz-variat")
+
+data = load_arviz_data("centered_eight")
+pc = azp.plot_pairs_focus(
+    data,
+    var_names=["theta","tau"],
+    focus_var="mu",
+    backend="none", # change to preferred backend
+)
+pc.show()

--- a/docs/source/gallery/inference_diagnostics/09_plot_pairs_focus.py
+++ b/docs/source/gallery/inference_diagnostics/09_plot_pairs_focus.py
@@ -1,7 +1,7 @@
 """
-# Pairwise focus distribution with divergence
+# Scatter plot with divergences
 
-Pairwise focus distribution of a variable against all other variables in the dataset.
+Plot one variable against other variables in the dataset.
 
 ---
 
@@ -9,17 +9,21 @@ Pairwise focus distribution of a variable against all other variables in the dat
 API Documentation: {func}`~arviz_plots.plot_pairs_focus`
 :::
 """
+import numpy as np
 from arviz_base import load_arviz_data
 
 import arviz_plots as azp
 
 azp.style.use("arviz-variat")
 
-data = load_arviz_data("centered_eight")
+dt = load_arviz_data("centered_eight")
+dt.posterior["log_tau"] = np.log(dt.posterior["tau"])
+
 pc = azp.plot_pairs_focus(
-    data,
-    var_names=["theta","tau"],
-    focus_var="mu",
+    dt,
+    var_names=["theta"],
+    focus_var="log_tau",
+    visuals={"divergence":True},
     backend="none", # change to preferred backend
 )
 pc.show()

--- a/src/arviz_plots/backend/bokeh/__init__.py
+++ b/src/arviz_plots/backend/bokeh/__init__.py
@@ -588,8 +588,9 @@ def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
         setattr(target.yaxis, f"axis_label_{key}", value)
 
 
-def xlabel(string, target, *, size=unset, color=unset, **artist_kws):
+def xlabel(string, target, *, size=unset, share=False, color=unset, **artist_kws):
     """Interface to bokeh for adding a label to the x axis."""
+    _ = share  # noqa: F841
     kwargs = {"text_font_size": _float_or_str_size(size), "text_color": color}
     target.xaxis.axis_label = string
     for key, value in _filter_kwargs(kwargs, artist_kws).items():

--- a/src/arviz_plots/backend/bokeh/__init__.py
+++ b/src/arviz_plots/backend/bokeh/__init__.py
@@ -588,7 +588,7 @@ def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
         setattr(target.yaxis, f"axis_label_{key}", value)
 
 
-def xlabel(string, target, *, size=unset, share=False, color=unset, **artist_kws):
+def xlabel(string, target, *, size=unset, share=True, color=unset, **artist_kws):
     """Interface to bokeh for adding a label to the x axis."""
     _ = share  # noqa: F841
     kwargs = {"text_font_size": _float_or_str_size(size), "text_color": color}

--- a/src/arviz_plots/backend/matplotlib/__init__.py
+++ b/src/arviz_plots/backend/matplotlib/__init__.py
@@ -459,7 +459,7 @@ def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
     return target.set_ylabel(string, **_filter_kwargs(kwargs, Text, artist_kws))
 
 
-def xlabel(string, target, *, size=unset, share=False, color=unset, **artist_kws):
+def xlabel(string, target, *, size=unset, share=True, color=unset, **artist_kws):
     """Interface to matplotlib for adding a label to the x axis."""
     _ = share  # noqa: F841
     kwargs = {"fontsize": size, "color": color}

--- a/src/arviz_plots/backend/matplotlib/__init__.py
+++ b/src/arviz_plots/backend/matplotlib/__init__.py
@@ -459,8 +459,9 @@ def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
     return target.set_ylabel(string, **_filter_kwargs(kwargs, Text, artist_kws))
 
 
-def xlabel(string, target, *, size=unset, color=unset, **artist_kws):
+def xlabel(string, target, *, size=unset, share=False, color=unset, **artist_kws):
     """Interface to matplotlib for adding a label to the x axis."""
+    _ = share  # noqa: F841
     kwargs = {"fontsize": size, "color": color}
     return target.set_xlabel(string, **_filter_kwargs(kwargs, Text, artist_kws))
 

--- a/src/arviz_plots/backend/none/__init__.py
+++ b/src/arviz_plots/backend/none/__init__.py
@@ -478,7 +478,7 @@ def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
     return artist_element
 
 
-def xlabel(string, target, *, size=unset, share=False, color=unset, **artist_kws):
+def xlabel(string, target, *, size=unset, share=True, color=unset, **artist_kws):
     """Interface to adding a label to a plot's x axis."""
     _ = share  # noqa: F841
     kwargs = {"color": color, "size": size}

--- a/src/arviz_plots/backend/none/__init__.py
+++ b/src/arviz_plots/backend/none/__init__.py
@@ -478,12 +478,17 @@ def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
     return artist_element
 
 
-def xlabel(string, target, *, size=unset, color=unset, **artist_kws):
+def xlabel(string, target, *, size=unset, share=False, color=unset, **artist_kws):
     """Interface to adding a label to a plot's x axis."""
+    _ = share  # noqa: F841
     kwargs = {"color": color, "size": size}
     if not ALLOW_KWARGS and artist_kws:
         raise ValueError(f"artist_kws not empty: {artist_kws}")
-    artist_element = {"function": "xlabel", "string": string, **_filter_kwargs(kwargs, artist_kws)}
+    artist_element = {
+        "function": "xlabel",
+        "string": string,
+        **_filter_kwargs(kwargs, artist_kws),
+    }
     target.append(artist_element)
     return artist_element
 

--- a/src/arviz_plots/backend/plotly/__init__.py
+++ b/src/arviz_plots/backend/plotly/__init__.py
@@ -686,14 +686,13 @@ def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
     )
 
 
-def xlabel(string, target, *, size=unset, color=unset, **artist_kws):
+def xlabel(string, target, *, size=unset, share=False, color=unset, **artist_kws):
     """Interface to plotly for adding a label to the y axis."""
     kwargs = {"size": size, "color": color}
-
     # Check if the x axis is shared
     is_shared_x_val = is_shared_x(target.figure)
     row, _ = target.figure._get_subplot_rows_columns()  # pylint: disable=protected-access
-    if is_shared_x_val and target.row != row[len(row) - 1]:
+    if is_shared_x_val and target.row != row[len(row) - 1] and share is False:
         return
 
     target.update_xaxes(

--- a/src/arviz_plots/backend/plotly/__init__.py
+++ b/src/arviz_plots/backend/plotly/__init__.py
@@ -686,13 +686,13 @@ def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
     )
 
 
-def xlabel(string, target, *, size=unset, share=False, color=unset, **artist_kws):
+def xlabel(string, target, *, size=unset, share=True, color=unset, **artist_kws):
     """Interface to plotly for adding a label to the y axis."""
     kwargs = {"size": size, "color": color}
     # Check if the x axis is shared
     is_shared_x_val = is_shared_x(target.figure)
     row, _ = target.figure._get_subplot_rows_columns()  # pylint: disable=protected-access
-    if is_shared_x_val and target.row != row[len(row) - 1] and share is False:
+    if is_shared_x_val and target.row != row[len(row) - 1] and share:
         return
 
     target.update_xaxes(

--- a/src/arviz_plots/plots/__init__.py
+++ b/src/arviz_plots/plots/__init__.py
@@ -13,7 +13,7 @@ from .evolution_plot import plot_ess_evolution
 from .forest_plot import plot_forest
 from .loo_pit_plot import plot_loo_pit
 from .mcse_plot import plot_mcse
-from .pair_focus_plot import plot_pair_focus
+from .pairs_focus_plot import plot_pairs_focus
 from .pava_calibration_plot import plot_ppc_pava
 from .ppc_dist_plot import plot_ppc_dist
 from .ppc_pit_plot import plot_ppc_pit
@@ -56,7 +56,7 @@ __all__ = [
     "plot_ppc_tstat",
     "plot_psense_dist",
     "plot_psense_quantities",
-    "plot_pair_focus",
+    "plot_pairs_focus",
     "add_lines",
     "add_bands",
 ]

--- a/src/arviz_plots/plots/__init__.py
+++ b/src/arviz_plots/plots/__init__.py
@@ -13,6 +13,7 @@ from .evolution_plot import plot_ess_evolution
 from .forest_plot import plot_forest
 from .loo_pit_plot import plot_loo_pit
 from .mcse_plot import plot_mcse
+from .pair_focus_plot import plot_pair_focus
 from .pava_calibration_plot import plot_ppc_pava
 from .ppc_dist_plot import plot_ppc_dist
 from .ppc_pit_plot import plot_ppc_pit
@@ -55,6 +56,7 @@ __all__ = [
     "plot_ppc_tstat",
     "plot_psense_dist",
     "plot_psense_quantities",
+    "plot_pair_focus",
     "add_lines",
     "add_bands",
 ]

--- a/src/arviz_plots/plots/pair_focus_plot.py
+++ b/src/arviz_plots/plots/pair_focus_plot.py
@@ -1,0 +1,236 @@
+"""Pair focus plot code."""
+from copy import copy
+from importlib import import_module
+
+import numpy as np
+from arviz_base import rcParams
+from arviz_base.labels import BaseLabeller
+
+from arviz_plots.plot_collection import PlotCollection, leaf_dataset, process_facet_dims
+from arviz_plots.plots.utils import filter_aes, get_group, process_group_variables_coords
+from arviz_plots.visuals import divergence_scatter, labelled_title, scatter_x
+
+
+def plot_pair_focus(
+    dt,
+    var_names=None,
+    target_name=None,
+    filter_vars=None,
+    group="posterior",
+    coords=None,
+    target_coords=None,
+    sample_dims=None,
+    plot_collection=None,
+    backend=None,
+    labeller=None,
+    aes_by_visuals=None,
+    visuals=None,
+    **pc_kwargs,
+):
+    """Plot pair focus plot of a variable against all other variables in the dataset.
+
+    Parameters
+    ----------
+    dt : DataTree
+        Input data
+    var_names: str or list of str, optional
+        One or more variables to be plotted.
+        Prefix the variables by ~ when you want to exclude them from the plot.
+    target_name: str
+        Name of the variable to be plotted against all other variables.
+    filter_vars: {None, “like”, “regex”}, optional, default=None
+        If None (default), interpret var_names as the real variables names.
+        If “like”, interpret var_names as substrings of the real variables names.
+        If “regex”, interpret var_names as regular expressions on the real variables names.
+    group : str, optional
+        Group to use for plotting. Defaults to "posterior".
+    coords : mapping, optional
+        Coordinates to use for plotting. Defaults to None.
+    target_coords : mapping, optional
+        Coordinates to use for the target variable. Defaults to None.
+    sample_dims : iterable, optional
+        Dimensions to reduce unless mapped to an aesthetic.
+        Defaults to ``rcParams["data.sample_dims"]``
+    plot_collection : PlotCollection, optional
+    backend : {"matplotlib", "bokeh","plotly"}, optional
+    labeller : labeller, optional
+    aes_by_visuals : mapping, optional
+        Mapping of visuals to aesthetics that should use their mapping in `plot_collection`
+        when plotted. Valid keys are the same as for `visuals`.
+    visuals : mapping of {str : mapping or False}, optional
+        Valid keys are:
+
+        * sample -> passed to :func:`~.visuals.scatter_x`
+        * divergence -> passed to :func:`~.visuals.divergence_scatter`
+        * title -> :func:`~.visuals.labelled_title`
+
+    pc_kwargs : mapping
+        Passed to :class:`arviz_plots.PlotCollection`
+
+    Returns
+    -------
+    PlotCollection
+
+    Examples
+    --------
+    The following examples focus on behaviour specific to ``plot_pair_focus``.
+    For a general introduction to batteries-included functions like this one and common
+    usage examples see :ref:`plots_intro`
+
+    Default plot_pair_focus
+
+    .. plot::
+        :context: close-figs
+
+        >>> from arviz_plots import plot_pair_plot, style
+        >>> style.use("arviz-variat")
+        >>> from arviz_base import load_arviz_data
+        >>> centered = load_arviz_data('centered_eight')
+        >>> target_name = "mu"
+        >>> var_names = ["theta", "tau"]
+        >>> pc = plot_trace(
+        >>>     centered,
+        >>>     var_names=var_names,
+        >>>     target_name=target_name,
+        >>>     backend="matplotlib",
+        >>> )
+        >>> pc.show()
+
+    """
+    if sample_dims is None:
+        sample_dims = rcParams["data.sample_dims"]
+    if isinstance(sample_dims, str):
+        sample_dims = [sample_dims]
+    if visuals is None:
+        visuals = {}
+    if pc_kwargs is None:
+        pc_kwargs = {}
+    else:
+        pc_kwargs = pc_kwargs.copy()
+
+    if aes_by_visuals is None:
+        aes_by_visuals = {}
+    else:
+        aes_by_visuals = aes_by_visuals.copy()
+
+    if backend is None:
+        if plot_collection is None:
+            backend = rcParams["plot.backend"]
+        else:
+            backend = plot_collection.backend
+
+    distribution = process_group_variables_coords(
+        dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords
+    )
+
+    plot_bknd = import_module(f".backend.{backend}", package="arviz_plots")
+
+    if plot_collection is None:
+        figsize = pc_kwargs.get("figure_kwargs", {}).get("figsize", None)
+        figsize_units = pc_kwargs.get("figure_kwargs", {}).get("figsize_units", "dots")
+        pc_kwargs.setdefault("col_wrap", 4)
+        pc_kwargs.setdefault(
+            "cols", ["__variable__"] + [dim for dim in distribution.dims if dim not in sample_dims]
+        )
+        n_plots, _ = process_facet_dims(distribution, pc_kwargs["cols"])
+        col_wrap = pc_kwargs["col_wrap"]
+        if n_plots <= col_wrap:
+            n_rows, n_cols = 1, n_plots
+        else:
+            div_mod = divmod(n_plots, col_wrap)
+            n_rows = div_mod[0] + (div_mod[1] != 0)
+            n_cols = col_wrap
+    else:
+        figsize, figsize_units = plot_bknd.get_figsize(plot_collection)
+        n_rows = leaf_dataset(plot_collection.viz, "row").max().to_array().max().item()
+        n_cols = leaf_dataset(plot_collection.viz, "col").max().to_array().max().item()
+
+    figsize = plot_bknd.scale_fig_size(
+        figsize,
+        rows=n_rows,
+        cols=n_cols,
+        figsize_units=figsize_units,
+    )
+
+    # scatter-pair-plot
+
+    if plot_collection is None:
+        pc_kwargs["aes"] = pc_kwargs.get("aes", {}).copy()
+        if "chain" in distribution:
+            pc_kwargs["aes"].setdefault("overlay", ["chain"])
+        pc_kwargs["figure_kwargs"] = pc_kwargs.get("figure_kwargs", {}).copy()
+        if "figsize" not in pc_kwargs["figure_kwargs"]:
+            pc_kwargs["figure_kwargs"]["figsize"] = figsize
+            pc_kwargs["figure_kwargs"]["figsize_units"] = figsize_units
+        pc_kwargs["figure_kwargs"].setdefault("sharex", True)
+        plot_collection = PlotCollection.wrap(
+            distribution,
+            backend=backend,
+            **pc_kwargs,
+        )
+
+    y = (
+        dt.posterior[target_name].sel(target_coords)
+        if target_coords is not None
+        else dt.posterior[target_name]
+    )
+    aes_by_visuals["sample"] = {"overlay"}.union(aes_by_visuals.get("sample", {}))
+    sample_kwargs = copy(visuals.get("sample", {}))
+    sample_kwargs.setdefault("alpha", 0.5)
+    sample_kwargs.setdefault("color", "#3f90da")
+    _, _, sample_ignore = filter_aes(plot_collection, aes_by_visuals, "sample", sample_dims)
+
+    plot_collection.map(
+        scatter_x,
+        "sample",
+        ignore_aes=sample_ignore,
+        y=y,
+        **sample_kwargs,
+    )
+
+    # divergences
+
+    aes_by_visuals["divergence"] = {"overlay"}.union(aes_by_visuals.get("divergence", {}))
+    div_kwargs = copy(visuals.get("divergence", {}))
+    sample_stats = get_group(dt, "sample_stats", allow_missing=True)
+    if (
+        div_kwargs is not False
+        and sample_stats is not None
+        and "diverging" in sample_stats.data_vars
+        and np.any(sample_stats.diverging)
+    ):
+        divergence_mask = dt.sample_stats.diverging
+        _, div_aes, div_ignore = filter_aes(
+            plot_collection, aes_by_visuals, "divergence", sample_dims
+        )
+        if "color" not in div_aes:
+            div_kwargs.setdefault("color", "black")
+        div_kwargs.setdefault("alpha", 0.4)
+        plot_collection.map(
+            divergence_scatter,
+            "divergence",
+            ignore_aes=div_ignore,
+            y=y,
+            mask=divergence_mask,
+            **div_kwargs,
+        )
+
+        # title of plots
+
+        if labeller is None:
+            labeller = BaseLabeller()
+
+        title_kwargs = copy(visuals.get("title", {}))
+        _, _, title_ignore = filter_aes(plot_collection, aes_by_visuals, "title", sample_dims)
+
+        plot_collection.map(
+            labelled_title,
+            "title",
+            subset_info=True,
+            labeller=labeller,
+            ignore_aes=title_ignore,
+            size=8,
+            **title_kwargs,
+        )
+
+    return plot_collection

--- a/src/arviz_plots/plots/pairs_focus_plot.py
+++ b/src/arviz_plots/plots/pairs_focus_plot.py
@@ -75,21 +75,21 @@ def plot_pairs_focus(
     Returns
     -------
     PlotCollection
+
     Examples
     --------
-
     Default plot_pair_focus
 
     .. plot::
         :context: close-figs
 
-        >>> from arviz_plots import plot_pair_plot, style
+        >>> from arviz_plots import plot_pairs_focus, style
         >>> style.use("arviz-variat")
         >>> from arviz_base import load_arviz_data
         >>> centered = load_arviz_data('centered_eight')
         >>> focus_var = "mu"
         >>> var_names = ["theta", "tau"]
-        >>> pc = plot_trace(
+        >>> pc = plot_pairs_focus(
         >>>     centered,
         >>>     var_names=var_names,
         >>>     focus_var=focus_var,
@@ -188,22 +188,22 @@ def plot_pairs_focus(
             **div_kwargs,
         )
 
-        # title of plots
+    # title of plots
 
-        if labeller is None:
-            labeller = BaseLabeller()
+    if labeller is None:
+        labeller = BaseLabeller()
 
-        title_kwargs = copy(visuals.get("title", {}))
-        _, _, title_ignore = filter_aes(plot_collection, aes_by_visuals, "title", sample_dims)
+    title_kwargs = copy(visuals.get("title", {}))
+    _, _, title_ignore = filter_aes(plot_collection, aes_by_visuals, "title", sample_dims)
 
-        plot_collection.map(
-            labelled_title,
-            "title",
-            subset_info=True,
-            labeller=labeller,
-            ignore_aes=title_ignore,
-            size=8,
-            **title_kwargs,
-        )
+    plot_collection.map(
+        labelled_title,
+        "title",
+        subset_info=True,
+        labeller=labeller,
+        ignore_aes=title_ignore,
+        size=8,
+        **title_kwargs,
+    )
 
     return plot_collection

--- a/src/arviz_plots/plots/pairs_focus_plot.py
+++ b/src/arviz_plots/plots/pairs_focus_plot.py
@@ -13,7 +13,7 @@ from arviz_plots.plots.utils import (
     process_group_variables_coords,
     set_wrap_layout,
 )
-from arviz_plots.visuals import divergence_scatter, labelled_title, scatter_x
+from arviz_plots.visuals import divergence_scatter, labelled_x, labelled_y, scatter_x
 
 
 def plot_pairs_focus(
@@ -192,22 +192,31 @@ def plot_pairs_focus(
             **div_kwargs,
         )
 
-    # title of plots
-
     if labeller is None:
         labeller = BaseLabeller()
 
-    title_kwargs = copy(visuals.get("title", {}))
-    _, _, title_ignore = filter_aes(plot_collection, aes_by_visuals, "title", sample_dims)
+    # xlabel of plots
 
+    xlabel_kwargs = copy(visuals.get("xlabel", {}))
+    _, _, xlabel_ignore = filter_aes(plot_collection, aes_by_visuals, "xlabel", sample_dims)
     plot_collection.map(
-        labelled_title,
-        "title",
+        labelled_x,
+        "xlabel",
         subset_info=True,
+        ignore_aes=xlabel_ignore,
         labeller=labeller,
-        ignore_aes=title_ignore,
-        size=8,
-        **title_kwargs,
+        **xlabel_kwargs,
+    )
+
+    # ylabel of plots
+    ylabel_kwargs = copy(visuals.get("ylabel", {}))
+    _, _, ylabel_ignore = filter_aes(plot_collection, aes_by_visuals, "ylabel", sample_dims)
+    plot_collection.map(
+        labelled_y,
+        "ylabel",
+        ignore_aes=ylabel_ignore,
+        text=focus_var,
+        **ylabel_kwargs,
     )
 
     return plot_collection

--- a/src/arviz_plots/plots/pairs_focus_plot.py
+++ b/src/arviz_plots/plots/pairs_focus_plot.py
@@ -116,6 +116,9 @@ def plot_pairs_focus(
         else:
             backend = plot_collection.backend
 
+    if var_names is None:
+        var_names = "~" + focus_var
+
     distribution = process_group_variables_coords(
         dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords
     )
@@ -131,7 +134,7 @@ def plot_pairs_focus(
         pc_kwargs["aes"] = pc_kwargs.get("aes", {}).copy()
         if "chain" in distribution:
             pc_kwargs["aes"].setdefault("overlay", ["chain"])
-        pc_kwargs["figure_kwargs"].setdefault("sharex", True)
+        pc_kwargs["figure_kwargs"].setdefault("sharey", True)
         plot_collection = PlotCollection.wrap(
             distribution,
             backend=backend,

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -101,6 +101,16 @@ def scatter_x(da, target, y=None, **kwargs):
     return plot_backend.scatter(da, y, target, **kwargs)
 
 
+def divergence_scatter(da, target, mask, y=None, **kwargs):
+    """Plot a dot/rug/scatter along the x axis (y constant)."""
+    if y is None:
+        y = np.zeros_like(da)
+    if np.asarray(y).size == 1:
+        y = np.zeros_like(da) + (y.item() if hasattr(y, "item") else y)
+    plot_backend = backend_from_object(target)
+    return plot_backend.scatter(da[mask], y[mask], target, **kwargs)
+
+
 def scatter_xy(da, target, x=None, y=None, **kwargs):
     """Plot a scatter plot x vs y.
 


### PR DESCRIPTION
As discussed in PR #276 , for plotly we need to find a way to enable users to share just x axis , as well as share both x axis and x label. Plotly and the other two backend libraries share just axis by default, but this causes problem in plotly because x label conflicts with the title of lower row plots. So we were forced to  share label also whenever sharex is true in plotly. 

But now , since we encountered the cases where we would like to share just the axis and not label in plotly. So this PR implements a work around which just affects the behaviour of plotly backend and behaviour of other two backends remain same. 

The user can now pass a new key named `share` with `False` value as `visuals = { "xlabel" : {"share": False}}`, which will enable user to not share the xlabels. 

For example:

```python
from arviz_base import load_arviz_data
import arviz_plots as azp

azp.style.use("arviz-variat")
idata = load_arviz_data("centered_eight")
focus_var = "mu"
visuals = {"divergence": True}
pc = azp.plot_pairs_focus(
    idata,
    var_names=["theta","tau"],
    focus_var=focus_var,
    backend="plotly",
    visuals = visuals,
    figure_kwargs={"sharex": True}
)
pc.show()

```

the above code gives output:

![image](https://github.com/user-attachments/assets/d2940b2a-1ea1-4538-849a-586c005ccb9c)

Both axis and label is shared

and code with `share` as `False` :
```python
visuals = {"divergence": True , "xlabel": {"share": False}}
pc = azp.plot_pairs_focus(
    idata,
    var_names=["theta","tau"],
    focus_var=focus_var,
    backend="plotly",
    visuals = visuals,
    figure_kwargs={"sharex": True}
)
pc.show()
```

gives output as:

![image](https://github.com/user-attachments/assets/42864e29-01db-4b08-9030-bee20d33a360)

here just the axis is shared, not label.

