### PR TITLE
Fixes share axis and share label feature in plotly

### DIFF
--- a/src/arviz_plots/backend/bokeh/__init__.py
+++ b/src/arviz_plots/backend/bokeh/__init__.py
@@ -588,8 +588,9 @@ def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
         setattr(target.yaxis, f"axis_label_{key}", value)
 
 
-def xlabel(string, target, *, size=unset, color=unset, **artist_kws):
+def xlabel(string, target, *, size=unset, share=True, color=unset, **artist_kws):
     """Interface to bokeh for adding a label to the x axis."""
+    _ = share  # noqa: F841
     kwargs = {"text_font_size": _float_or_str_size(size), "text_color": color}
     target.xaxis.axis_label = string
     for key, value in _filter_kwargs(kwargs, artist_kws).items():

--- a/src/arviz_plots/backend/matplotlib/__init__.py
+++ b/src/arviz_plots/backend/matplotlib/__init__.py
@@ -459,8 +459,9 @@ def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
     return target.set_ylabel(string, **_filter_kwargs(kwargs, Text, artist_kws))
 
 
-def xlabel(string, target, *, size=unset, color=unset, **artist_kws):
+def xlabel(string, target, *, size=unset, share=True, color=unset, **artist_kws):
     """Interface to matplotlib for adding a label to the x axis."""
+    _ = share  # noqa: F841
     kwargs = {"fontsize": size, "color": color}
     return target.set_xlabel(string, **_filter_kwargs(kwargs, Text, artist_kws))
 

--- a/src/arviz_plots/backend/none/__init__.py
+++ b/src/arviz_plots/backend/none/__init__.py
@@ -478,8 +478,9 @@ def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
     return artist_element
 
 
-def xlabel(string, target, *, size=unset, color=unset, **artist_kws):
+def xlabel(string, target, *, size=unset, share=True, color=unset, **artist_kws):
     """Interface to adding a label to a plot's x axis."""
+    _ = share  # noqa: F841
     kwargs = {"color": color, "size": size}
     if not ALLOW_KWARGS and artist_kws:
         raise ValueError(f"artist_kws not empty: {artist_kws}")

--- a/src/arviz_plots/backend/plotly/__init__.py
+++ b/src/arviz_plots/backend/plotly/__init__.py
@@ -686,14 +686,14 @@ def ylabel(string, target, *, size=unset, color=unset, **artist_kws):
     )
 
 
-def xlabel(string, target, *, size=unset, color=unset, **artist_kws):
+def xlabel(string, target, *, size=unset, share=True, color=unset, **artist_kws):
     """Interface to plotly for adding a label to the y axis."""
     kwargs = {"size": size, "color": color}
 
     # Check if the x axis is shared
     is_shared_x_val = is_shared_x(target.figure)
     row, _ = target.figure._get_subplot_rows_columns()  # pylint: disable=protected-access
-    if is_shared_x_val and target.row != row[len(row) - 1]:
+    if is_shared_x_val and target.row != row[len(row) - 1] and share:
         return
 
     target.update_xaxes(


### PR DESCRIPTION
As discussed in PR #276 , for plotly we need to find a way to enable users to share just x axis , as well as share both x axis and x label. Plotly and the other two backend libraries share just axis by default, but this causes problem in plotly because x label conflicts with the title of lower row plots. So we were forced to  share label also whenever sharex is true in plotly. 

But now , since we encountered the cases where we would like to share just the axis and not label in plotly. So this PR implements a work around which just affects the behaviour of plotly backend and behaviour of other two backends remain same. 

The user can now pass a new key named `share` with `False` value as `visuals = { "xlabel" : {"share": False}}`, which will enable user to not share the xlabels. 

For example:

```python
from arviz_base import load_arviz_data
import arviz_plots as azp

azp.style.use("arviz-variat")
idata = load_arviz_data("centered_eight")
focus_var = "mu"
visuals = {"divergence": True}
pc = azp.plot_pairs_focus(
    idata,
    var_names=["theta","tau"],
    focus_var=focus_var,
    backend="plotly",
    visuals = visuals,
    figure_kwargs={"sharex": True}
)
pc.show()

```

the above code gives output:

![image](https://github.com/user-attachments/assets/c63a2be5-94b5-4213-b398-3c21dc2a1717)


Both axis and label is shared

and code with `share` as `False` :
```python
visuals = {"divergence": True , "xlabel": {"share": False}}
pc = azp.plot_pairs_focus(
    idata,
    var_names=["theta","tau"],
    focus_var=focus_var,
    backend="plotly",
    visuals = visuals,
    figure_kwargs={"sharex": True}
)
pc.show()
```

gives output as:

![image](https://github.com/user-attachments/assets/a3d5e240-573a-4293-8c75-73c2bc89f758)

here just the axis is shared, not label.
