### PR TITLE
raise when extra keyword arguments make it to aes generation

### DIFF
--- a/src/arviz_plots/plot_collection.py
+++ b/src/arviz_plots/plot_collection.py
@@ -510,6 +510,13 @@ class PlotCollection:
         if data is None:
             data = self.data
         aes = {key: value for key, value in aes.items() if value is not False}
+        extra_keys = [key for key in kwargs if key not in aes]
+        if extra_keys:
+            raise ValueError(
+                f"Keyword arguments {extra_keys} have been passed as **kwargs but "
+                "have no active aesthetic mapped to them. Keyword arguments must define "
+                "values to use in their respective aesthetic mapping."
+            )
         if not hasattr(self, "backend"):
             plot_bknd = import_module(".backend.none", package="arviz_plots")
         else:

--- a/src/arviz_plots/plots/compare_plot.py
+++ b/src/arviz_plots/plots/compare_plot.py
@@ -91,9 +91,9 @@ def plot_compare(
     p_be = import_module(f"arviz_plots.backend.{backend}")
 
     # Get figure params and create figure and axis
-    pc_kwargs["figure_kwargs"] = pc_kwargs.get("figure_kwargs", {}).copy()
-    figsize = pc_kwargs.get("figure_kwargs", {}).get("figsize", None)
-    figsize_units = pc_kwargs["figure_kwargs"].get("figsize_units", "inches")
+    figure_kwargs = pc_kwargs.pop("figure_kwargs", {}).copy()
+    figsize = figure_kwargs.pop("figsize", None)
+    figsize_units = figure_kwargs.pop("figsize_units", None)
 
     figsize = p_be.scale_fig_size(
         figsize,
@@ -103,7 +103,9 @@ def plot_compare(
     )
     figsize_units = "dots"
 
-    figure, target = p_be.create_plotting_grid(1, figsize=figsize, figsize_units=figsize_units)
+    figure, target = p_be.create_plotting_grid(
+        1, figsize=figsize, figsize_units=figsize_units, **figure_kwargs
+    )
 
     # Create plot collection
     plot_collection = PlotCollection(

--- a/src/arviz_plots/plots/pava_calibration_plot.py
+++ b/src/arviz_plots/plots/pava_calibration_plot.py
@@ -161,7 +161,6 @@ def plot_ppc_pava(
         pc_kwargs["figure_kwargs"] = pc_kwargs.get("figure_kwargs", {}).copy()
 
         pc_kwargs["aes"] = pc_kwargs.get("aes", {}).copy()
-        pc_kwargs.setdefault("rows", None)
         pc_kwargs.setdefault("cols", ["__variable__"])
         pc_kwargs = set_wrap_layout(pc_kwargs, plot_bknd, ds_calibration)
 

--- a/src/arviz_plots/plots/ppc_dist_plot.py
+++ b/src/arviz_plots/plots/ppc_dist_plot.py
@@ -211,7 +211,6 @@ def plot_ppc_dist(
         pc_kwargs["aes"] = pc_kwargs.get("aes", {}).copy()
         pc_kwargs["aes"].setdefault("overlay_ppc", ["sample"])
         pc_kwargs.setdefault("cols", "__variable__")
-        pc_kwargs.setdefault("rows", None)
 
         pc_kwargs = set_wrap_layout(pc_kwargs, plot_bknd, predictive_dist)
 

--- a/src/arviz_plots/plots/ppc_pit_plot.py
+++ b/src/arviz_plots/plots/ppc_pit_plot.py
@@ -202,7 +202,6 @@ def plot_ppc_pit(
         pc_kwargs["figure_kwargs"].setdefault("sharex", True)
         pc_kwargs["aes"] = pc_kwargs.get("aes", {}).copy()
         pc_kwargs.setdefault("cols", "__variable__")
-        pc_kwargs.setdefault("rows", None)
 
         pc_kwargs = set_wrap_layout(pc_kwargs, plot_bknd, ds_ecdf)
 

--- a/src/arviz_plots/plots/ppc_rootogram_plot.py
+++ b/src/arviz_plots/plots/ppc_rootogram_plot.py
@@ -196,7 +196,6 @@ def plot_ppc_rootogram(
 
         pc_kwargs["aes"] = pc_kwargs.get("aes", {}).copy()
         pc_kwargs.setdefault("cols", "__variable__")
-        pc_kwargs.setdefault("rows", None)
 
         pc_kwargs = set_wrap_layout(pc_kwargs, plot_bknd, ds_predictive)
 

--- a/src/arviz_plots/plots/ppc_tstat.py
+++ b/src/arviz_plots/plots/ppc_tstat.py
@@ -267,7 +267,6 @@ def plot_ppc_tstat(
 
         pc_kwargs["aes"] = pc_kwargs.get("aes", {}).copy()
         pc_kwargs.setdefault("cols", "__variable__")
-        pc_kwargs.setdefault("rows", None)
 
         pc_kwargs = set_wrap_layout(pc_kwargs, plot_bknd, predictive_dist)
 

--- a/src/arviz_plots/plots/trace_dist_plot.py
+++ b/src/arviz_plots/plots/trace_dist_plot.py
@@ -200,13 +200,15 @@ def plot_trace_dist(
         )
     if not compact and combined:
         neutral_color = color_cycle[0]
-        pc_kwargs["color"] = color_cycle[1:]
+        if "chain" in distribution.dims:
+            pc_kwargs["color"] = color_cycle[1:]
     else:
         neutral_color = False
 
     if compact and combined:
         neutral_linestyle = linestyle_cycle[0]
-        pc_kwargs["linestyle"] = linestyle_cycle[1:]
+        if "chain" in distribution.dims:
+            pc_kwargs["linestyle"] = linestyle_cycle[1:]
     else:
         neutral_linestyle = False
 


### PR DESCRIPTION
I do typos quite often and so far they are hard to notice because
any incorrect kwarg will be passed through to the function that generates
aesthetic mappings which only accesses the `**kwargs` it gets by key,
so extra kwargs are silently ignored.

I modified the behaviour so they raise an error now and updated the functions
that were sending keyword arguments only for them to be silently ignored.
