### PR TITLE
Allow using "AX" notation for aliases to default aes cycle

### DIFF
--- a/src/arviz_plots/backend/matplotlib/__init__.py
+++ b/src/arviz_plots/backend/matplotlib/__init__.py
@@ -119,6 +119,37 @@ def get_default_aes(aes_key, n, kwargs=None):
     return get_agnostic_default_aes(aes_key, n, kwargs)
 
 
+def dealiase_aes_value(aes, value):
+    try:
+        if value.startswith(f"{aes}_"):
+            index = int(value.rsplit("_")[-1])
+        else:
+            index = int(value[1:])
+        dealiased_value = get_default_aes(aes, index+1)[index]
+    except ValueError:
+        return value
+    return dealiased_value
+
+
+def expand_aesthetic_aliases(plot_fn):
+    def _dealiased_plot_fn(*args, **kwargs):
+        for aes in ("color", "facecolor", "edgecolor"):
+            if (
+                aes in kwargs 
+                and isinstance(value := kwargs[aes], str)
+                and (value[0].lower() in ("c", aes[0]) or value.startswith(f"{aes}_"))
+            ):
+                kwargs[aes] = dealiase_aes_value(aes, value)
+        for aes in ("linestyle", "marker"):
+            if (
+                aes in kwargs 
+                and isinstance(value := kwargs[aes], str)
+                and (value[0].lower() == aes[0] or value.startswith(f"{aes}_"))
+            ):
+                kwargs[aes] = dealiase_aes_value(aes, value)
+        return plot_fn(*args, **kwargs)
+    return _dealiased_plot_fn
+
 def scale_fig_size(figsize, rows=1, cols=1, figsize_units=None):
     """Scale figure properties according to figsize, rows and cols.
 
@@ -319,6 +350,7 @@ def hist(
     )
 
 
+@expand_aesthetic_aliases
 def line(x, y, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
     """Interface to matplotlib for a line plot."""
     artist_kws.setdefault("zorder", 2)


### PR DESCRIPTION
I will try to combine the functionality with what we have in `combine_plots` (or relegate that part of `combine_plots` so it always happens automatically). The main question I have is we currently use `{aes}_{i}` as placeholders in the none backend, so `color_12`. This initial version allows both notations, `color_12`, `linestyle_3` or `C12`, `L3` but I think we should choose only one. We can either change the placeholders of the none backend to the `C12` convention or support dealiasing only the verbose placeholders of the none backend.

Example:

```python
azp.plot_dist(data, visuals={"dist": {"color": "C3", "linestyle": "L1"}});
```

<img width="1210" height="505" alt="example" src="https://github.com/user-attachments/assets/7a6cdc96-6c97-49a1-831e-5761915fea83" />
