### PR TITLE
Restrict pallete to eight colors

### DIFF
--- a/src/arviz_plots/styles/arviz-cetrino.mplstyle
+++ b/src/arviz_plots/styles/arviz-cetrino.mplstyle
@@ -54,9 +54,8 @@ axes.labelcolor:        .15
 axes.labelweight:       normal      # weight of the x and y labels
 
 # color-blind friendly cycle designed using https://colorcyclepicker.mpetroff.net/
-# see preview and check for colorblindness here https://coolors.co/009988-9238b2-d2225f-ec8f26-fcd026-3cd186-a57119-2f5e14-f225f4-8f9fbf
-axes.prop_cycle: cycler(color=["009988", "9238b2", "d2225f", "ec8f26", "fcd026", "3cd186", "a57119", "2f5e14", "f225f4", "8f9fbf"])
-
+# see preview and check for colorblindness here https://coolors.co/3cd186-fcd026-ec8f26-c969eb-2b8c92-a91a32-2f2cec-958152
+axes.prop_cycle: cycler(color=["3cd186","fcd026","ec8f26","c969eb","2b8c92","a91a32","2f2cec","958152"])
 image.cmap: viridis
 
 ## ***************************************************************************

--- a/src/arviz_plots/styles/arviz-cetrino.yml
+++ b/src/arviz_plots/styles/arviz-cetrino.yml
@@ -18,8 +18,8 @@ attrs:
         text_font_style: 'bold'
     Cycler:
         colors : [
-                '#009988', '#9238b2', '#d2225f', '#ec8f26', '#fcd026',
-                '#3cd186', '#a57119', '#2f5e14', '#f225f4', '#8f9fbf',
+                "#3cd186", "#fcd026", "#ec8f26", "#c969eb",
+                "#2b8c92", "#a91a32", "#2f2cec", "#958152",
             ]
 
 

--- a/src/arviz_plots/styles/arviz-variat.mplstyle
+++ b/src/arviz_plots/styles/arviz-variat.mplstyle
@@ -54,8 +54,9 @@ axes.labelcolor:        .15
 axes.labelweight:       normal      # weight of the x and y labels
 
 # color-blind friendly cycle designed using https://colorcyclepicker.mpetroff.net/
-# see preview and check for colorblindness here https://coolors.co/36acc6-f66d7f-fac364-7c2695-228306-a252f4-63f0ea-000000-6f6f6f-b7b7b7
-axes.prop_cycle: cycler(color=["36acc6", "f66d7f", "fac364", "7c2695", "228306", "a252f4", "63f0ea", "000000", "6f6f6f", "b7b7b7"])
+# see preview and check for colorblindness here https://coolors.co/36acc6-f66d7f-fac364-7c2695-228306-a252f4-63f0ea-a77e4f
+axes.prop_cycle: cycler(color=["36acc6", "f66d7f","fac364","7c2695","228306","a252f4","63f0ea","a77e4f"])
+
 
 image.cmap: viridis
 

--- a/src/arviz_plots/styles/arviz-variat.yml
+++ b/src/arviz_plots/styles/arviz-variat.yml
@@ -18,6 +18,6 @@ attrs:
         text_font_style: 'bold'
     Cycler:
         colors : [
-                '#36acc6', '#f66d7f', '#fac364', '#7c2695', '#228306',
-                '#a252f4', '#63f0ea', '#000000', '#6f6f6f', '#b7b7b7'
+                "#36acc6", "#f66d7f", "#fac364", "#7c2695",
+                "#228306", "#a252f4", "#63f0ea", "#a77e4f",
             ]

--- a/src/arviz_plots/styles/arviz-vibrant.mplstyle
+++ b/src/arviz_plots/styles/arviz-vibrant.mplstyle
@@ -54,8 +54,8 @@ axes.labelcolor:        .15
 axes.labelweight:       normal      # weight of the x and y labels
 
 # color-blind friendly cycle designed using https://colorcyclepicker.mpetroff.net/
-# see preview and check for colorblindness here https://coolors.co/008b92-f15c58-48cdef-98d81a-997ee5-f5dc9d-c90a4e-145393-323232-616161
-axes.prop_cycle: cycler(color=["008b92", "f15c58", "48cdef", "98d81a", "997ee5", "f5dc9d", "c90a4e", "145393", "323232", "616161"])
+# see preview and check for colorblindness here https://coolors.co/008b92-f15c58-48cdef-bc56f0-8ddb17-f9cf9c-c90a4e-b0aaa2
+axes.prop_cycle: cycler(color=["008b92","f15c58","48cdef","bc56f0","8ddb17","f9cf9c","c90a4e","b0aaa2"])
 image.cmap: viridis
 
 ## ***************************************************************************

--- a/src/arviz_plots/styles/arviz-vibrant.yml
+++ b/src/arviz_plots/styles/arviz-vibrant.yml
@@ -18,6 +18,6 @@ attrs:
         text_font_style: 'bold'
     Cycler:
         colors : [
-                '#008b92', '#f15c58', '#48cdef', '#98d81a', '#997ee5', 
-                '#f5dc9d', '#c90a4e', '#145393', '#323232', '#616161',
+                '#008b92', '#f15c58', '#48cdef', '#bc56f0',
+                '#8ddb17', '#f9cf9c', '#c90a4e', '#b0aaa2',
             ]


### PR DESCRIPTION
Given internal discussion and recommendations from Fundamentals of Data Visualization by Claus O. Wilke I am shortening the default color palette to eight colors. I also make some small tweaks to some of the colors.


<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--312.org.readthedocs.build/en/312/

<!-- readthedocs-preview arviz-plots end -->