### PR TITLE
update default ci_prob for ecdf-pit plots

### DIFF
--- a/src/arviz_plots/plots/ecdf_plot.py
+++ b/src/arviz_plots/plots/ecdf_plot.py
@@ -35,7 +35,7 @@ def plot_ecdf_pit(
     group="prior_sbc",
     coords=None,
     sample_dims=None,
-    ci_prob=None,
+    ci_prob=0.99,
     coverage=False,
     plot_collection=None,
     backend=None,
@@ -98,9 +98,9 @@ def plot_ecdf_pit(
     sample_dims : str or sequence of hashable, optional
         Dimensions to reduce unless mapped to an aesthetic.
         Defaults to ``rcParams["data.sample_dims"]``
-    ci_prob : float, optional
+    ci_prob : float
         Indicates the probability that should be contained within the plotted credible interval.
-        Defaults to ``rcParams["stats.ci_prob"]``
+        Defaults to 0.99.
     coverage : bool, optional
         If True, plot the coverage of the central posterior credible intervals. Defaults to False.
     plot_collection : PlotCollection, optional
@@ -155,8 +155,6 @@ def plot_ecdf_pit(
        its applications in goodness-of-fit evaluation and multiple sample comparison*.
        Statistics and Computing 32(32). (2022) https://doi.org/10.1007/s11222-022-10090-6
     """
-    if ci_prob is None:
-        ci_prob = rcParams["stats.ci_prob"]
     if sample_dims is None:
         sample_dims = rcParams["data.sample_dims"]
     if isinstance(sample_dims, str):

--- a/src/arviz_plots/plots/loo_pit_plot.py
+++ b/src/arviz_plots/plots/loo_pit_plot.py
@@ -11,7 +11,7 @@ from arviz_plots.plots.ecdf_plot import plot_ecdf_pit
 
 def plot_loo_pit(
     dt,
-    ci_prob=None,
+    ci_prob=0.99,
     coverage=False,
     var_names=None,
     filter_vars=None,  # pylint: disable=unused-argument
@@ -70,9 +70,9 @@ def plot_loo_pit(
     ----------
     dt : DataTree
         Input data
-    ci_prob : float, optional
+    ci_prob : float
         Indicates the probability that should be contained within the plotted credible interval.
-        Defaults to ``rcParams["stats.ci_prob"]``
+        Defaults to 0.99.
     coverage : bool, optional
         If True, plot the coverage of the central posterior credible intervals. Defaults to False.
     var_names : str or list of str, optional

--- a/src/arviz_plots/plots/ppc_pit_plot.py
+++ b/src/arviz_plots/plots/ppc_pit_plot.py
@@ -29,7 +29,7 @@ from arviz_plots.visuals import (
 
 def plot_ppc_pit(
     dt,
-    ci_prob=None,
+    ci_prob=0.99,
     coverage=False,
     var_names=None,
     data_pairs=None,
@@ -87,9 +87,9 @@ def plot_ppc_pit(
     ----------
     dt : DataTree
         Input data
-    ci_prob : float, optional
+    ci_prob : float
         Indicates the probability that should be contained within the plotted credible interval.
-        Defaults to ``rcParams["stats.ci_prob"]``
+        Defaults to 0.99.
     coverage : bool, optional
         If True, plot the coverage of the central posterior credible intervals. Defaults to False.
     data_pairs : dict, optional
@@ -170,8 +170,6 @@ def plot_ppc_pit(
        its applications in goodness-of-fit evaluation and multiple sample comparison*.
        Statistics and Computing 32(32). (2022) https://doi.org/10.1007/s11222-022-10090-6
     """
-    if ci_prob is None:
-        ci_prob = rcParams["stats.ci_prob"]
     if sample_dims is None:
         sample_dims = rcParams["data.sample_dims"]
     if isinstance(sample_dims, str):

--- a/src/arviz_plots/plots/rank_dist_plot.py
+++ b/src/arviz_plots/plots/rank_dist_plot.py
@@ -33,7 +33,7 @@ def plot_rank_dist(
     compact=True,
     combined=False,
     kind=None,
-    ci_prob=None,
+    ci_prob=0.99,
     plot_collection=None,
     backend=None,
     labeller=None,
@@ -88,10 +88,10 @@ def plot_rank_dist(
     kind : {"kde", "hist", "dot", "ecdf"}, optional
         How to represent the marginal density.
         Defaults to ``rcParams["plot.density_kind"]``
-    ci_prob : float, optional
+    ci_prob : float
         Indicates the probability that should be contained within the plotted credible interval for
         the fractional ranks.
-        Defaults to ``rcParams["stats.ci_prob"]``
+        Defaults to 0.99.
     plot_collection : PlotCollection, optional
     backend : {"matplotlib", "bokeh"}, optional
     labeller : labeller, optional

--- a/src/arviz_plots/plots/rank_plot.py
+++ b/src/arviz_plots/plots/rank_plot.py
@@ -27,7 +27,7 @@ def plot_rank(
     group="posterior",
     coords=None,
     sample_dims=None,
-    ci_prob=None,
+    ci_prob=0.99,
     plot_collection=None,
     backend=None,
     labeller=None,
@@ -81,9 +81,9 @@ def plot_rank(
     sample_dims : str or sequence of hashable, optional
         Dimensions to reduce unless mapped to an aesthetic.
         Defaults to ``rcParams["data.sample_dims"]``
-    ci_prob : float, optional
+    ci_prob : float
         Indicates the probability that should be contained within the plotted credible interval.
-        Defaults to ``rcParams["stats.ci_prob"]``
+        Defaults to 0.99.
     plot_collection : PlotCollection, optional
     backend : {"matplotlib", "bokeh", "plotly"}, optional
     labeller : labeller, optional
@@ -135,8 +135,6 @@ def plot_rank(
        its applications in goodness-of-fit evaluation and multiple sample comparison*.
        Statistics and Computing 32(32). (2022) https://doi.org/10.1007/s11222-022-10090-6
     """
-    if ci_prob is None:
-        ci_prob = rcParams["stats.ci_prob"]
     if sample_dims is None:
         sample_dims = rcParams["data.sample_dims"]
     if isinstance(sample_dims, str):


### PR DESCRIPTION
These plots are diagnostic plots, instead of summary plots.  And hence the role of `ci_prob` is slightly different from that in the other plots. I suggest we use the value 0.99, while arbitrary, it matches the one used in bayesplot.

Alternatively, we could rename the argument `ci_prob`  for these plots and add a matching entry in rcParams. Maybe something like  `env_prob` or `envelope_prob` and take the default value from there.