### PR TITLE
DOC: Correct a typo: appeareance -> appearance

### DIFF
--- a/docs/source/api/backend/interface.template.rst
+++ b/docs/source/api/backend/interface.template.rst
@@ -18,7 +18,7 @@ Geoms
    scatter
    text
 
-Plot appeareance
+Plot appearance
 ................
 
 .. autosummary::

--- a/src/arviz_plots/backend/none/__init__.py
+++ b/src/arviz_plots/backend/none/__init__.py
@@ -517,7 +517,7 @@ def ciliney(
     return artist_element
 
 
-# general plot appeareance
+# general plot appearance
 def title(string, target, *, size=unset, color=unset, **artist_kws):
     """Interface to adding a title to a plot."""
     kwargs = {"color": color, "size": size}


### PR DESCRIPTION
Correct a typo: appeareance -> appearance

<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--349.org.readthedocs.build/en/349/

<!-- readthedocs-preview arviz-plots end -->