### PR TITLE
DOC: Correct more typos in arviz-plots documentation

### DIFF
--- a/src/arviz_plots/backend/none/__init__.py
+++ b/src/arviz_plots/backend/none/__init__.py
@@ -4,7 +4,7 @@
 Interface to no plotting backend, returned processed data without interfacing to any plotting
 backend for actual drawing.
 
-:term:`plots` are lists which are extended with kwarg dictionaries every time an visual
+:term:`plots` are lists which are extended with kwarg dictionaries every time a visual
 would be added to them.
 """
 import warnings

--- a/src/arviz_plots/plot_collection.py
+++ b/src/arviz_plots/plot_collection.py
@@ -1000,7 +1000,7 @@ class PlotCollection:
         artist_dims=None,
         ignore_aes=frozenset(),
     ):
-        """Allocate an visual in the ``viz`` DataTree."""
+        """Allocate a visual in the ``viz`` DataTree."""
         if artist_dims is None:
             artist_dims = {}
         if dim_to_idx is None:

--- a/src/arviz_plots/plot_collection.py
+++ b/src/arviz_plots/plot_collection.py
@@ -713,7 +713,7 @@ class PlotCollection:
         figure_kwargs=None,
         **kwargs,
     ):
-        """Instatiate a PlotCollection and generate a plot grid iterating over subsets and wrapping.
+        """Instantiate a PlotCollection and generate a plot grid iterating over subsets and wrapping.
 
         Parameters
         ----------
@@ -854,7 +854,7 @@ class PlotCollection:
         figure_kwargs=None,
         **kwargs,
     ):
-        """Instatiate a PlotCollection and generate a plot grid iterating over rows and columns.
+        """Instantiate a PlotCollection and generate a plot grid iterating over rows and columns.
 
         Parameters
         ----------

--- a/src/arviz_plots/plot_collection.py
+++ b/src/arviz_plots/plot_collection.py
@@ -713,7 +713,7 @@ class PlotCollection:
         figure_kwargs=None,
         **kwargs,
     ):
-        """Instantiate a PlotCollection and generate a plot grid iterating over subsets and wrapping.
+        """Instantiate a PlotCollection and generate a grid iterating over subsets and wrapping.
 
         Parameters
         ----------

--- a/src/arviz_plots/plot_matrix.py
+++ b/src/arviz_plots/plot_matrix.py
@@ -196,7 +196,7 @@ class PlotMatrix(PlotCollection):
     def allocate_artist(
         self, fun_label, data, all_loop_dims, dim_to_idx=None, artist_dims=None, ignore_aes=None
     ):
-        """Allocate an visual in the ``viz`` DataTree."""
+        """Allocate a visual in the ``viz`` DataTree."""
         if artist_dims is None:
             artist_dims = {}
         if dim_to_idx:
@@ -224,7 +224,7 @@ class PlotMatrix(PlotCollection):
         Parameters
         ----------
         aux_artist
-            The plotting backend class representing an visual to be stored or
+            The plotting backend class representing a visual to be stored or
             an array-like of such objects.
         fun_label : hashable
             The identifier of the visual within the ``PlotMatrix``.


### PR DESCRIPTION
Correct more typos in arviz-plots documentation

<!-- readthedocs-preview arviz-plots start -->
----
📚 Documentation preview 📚: https://arviz-plots--350.org.readthedocs.build/en/350/

<!-- readthedocs-preview arviz-plots end -->