### PR TITLE
Change truncation_factor name to avoid possible confusions

### DIFF
--- a/docs/source/gallery/predictive_checks/09_plot_ppc_censored.py
+++ b/docs/source/gallery/predictive_checks/09_plot_ppc_censored.py
@@ -16,7 +16,7 @@ azp.style.use("arviz-variat")
 data = load_arviz_data("censored_cats")
 pc = azp.plot_ppc_censored(
     data,
-    truncation_factor=None,
+    extrapolation_factor=None,
     backend="none",
 )
 

--- a/src/arviz_plots/plots/ppc_censored_plot.py
+++ b/src/arviz_plots/plots/ppc_censored_plot.py
@@ -25,7 +25,7 @@ def plot_ppc_censored(
     coords=None,
     sample_dims=None,
     num_samples=100,
-    truncation_factor=1.2,
+    extrapolation_factor=1.2,
     plot_collection=None,
     backend=None,
     labeller=None,
@@ -55,9 +55,8 @@ def plot_ppc_censored(
 
     Instead of plotting the raw data observation and predictions, as is common in posterior
     predictive checks, this function computes the Kaplan-Meier survival curves for observed
-    and for predictive data computes the truncated survival probabilities. The truncation is
-    done as a factor of the maximum observed data to avoid extending the survival curves too
-    far beyond the range of observed data.
+    and for predictive data computes survival probabilities limited to a factor of the maximum
+    observed data to avoid extending the survival curves too far beyond the range of observed data.
 
     Parameters
     ----------
@@ -82,9 +81,9 @@ def plot_ppc_censored(
         Defaults to ``rcParams["data.sample_dims"]``
     num_samples : int, optional
         Number of samples to plot. Defaults to 100.
-    truncation_factor : float, default 1.2
-        Factor by which to truncate the survival curves beyond the maximum observed time.
-        Set to `None` to show all posterior predictive draws.
+    extrapolation_factor : float, default 1.2
+        Factor by which to limit the survival curves beyond the maximum observed time.
+        Set to None to show the unaffected posterior predictive draws.
     plot_collection : PlotCollection, optional
         Existing plot collection to add to.
     backend : {"matplotlib", "bokeh", "plotly"}, optional
@@ -180,7 +179,7 @@ def plot_ppc_censored(
         var_names=predictive_dist.data_vars,
         group=group,
         num_samples=num_samples,
-        truncation_factor=truncation_factor,
+        extrapolation_factor=extrapolation_factor,
     )
 
     plot_bknd = import_module(f".backend.{backend}", package="arviz_plots")

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -500,13 +500,13 @@ class TestPlots:  # pylint: disable=too-many-public-methods
         assert "diverging" not in pc.viz["xticks"].dims
         assert "labels" in pc.viz["xticks"].dims
 
-    @pytest.mark.parametrize("truncation_factor", [1.5, None])
-    def test_plot_ppc_censored(self, datatree_censored, backend, truncation_factor):
+    @pytest.mark.parametrize("extrapolation_factor", [1.5, None])
+    def test_plot_ppc_censored(self, datatree_censored, backend, extrapolation_factor):
         pc = plot_ppc_censored(
             datatree_censored,
             var_names="time",
             backend=backend,
-            truncation_factor=truncation_factor,
+            extrapolation_factor=extrapolation_factor,
         )
 
         assert "figure" in pc.viz.data_vars


### PR DESCRIPTION
Use `extrapolation_factor` (this is used in Bayesplot), the term  "truncation_factor", could lead to confusion, for example, in the context of left truncated data. Related to https://github.com/arviz-devs/arviz-stats/pull/240