### PR TITLE
Add plot_ppc_interval to API docs

### DIFF
--- a/docs/source/api/plots.rst
+++ b/docs/source/api/plots.rst
@@ -36,6 +36,7 @@ A complementary introduction and guide to ``plot_...`` functions is available at
    plot_parallel
    plot_ppc_censored
    plot_ppc_dist
+   plot_ppc_interval
    plot_ppc_pava
    plot_ppc_pit
    plot_ppc_rootogram


### PR DESCRIPTION
# Add `plot_ppc_interval` to API docs

## Description
This PR adds the missing `plot_ppc_interval` entry to the API documentation (`docs/source/api/plots.rst`), ensuring it appears in the generated docs.

## Context
As mentioned in issue #364, the function already has an example page and is part of the public API but wasn’t listed in the `plots.rst` autosummary section.

## Changes made
- Added `plot_ppc_interval` to the autosummary list under `docs/source/api/plots.rst`, near other `plot_ppc_*` functions.

Closes #364
