### PR TITLE
DOC: replace TODO with PlotCollection API reference

### DIFF
--- a/docs/source/tutorials/compose_own_plot.ipynb
+++ b/docs/source/tutorials/compose_own_plot.ipynb
@@ -1973,7 +1973,8 @@
    "id": "dd24d6b5-e60f-4bce-a569-da0ae39360c1",
    "metadata": {},
    "source": [
-    "Recall that faceting and aesthetics are independent mappings, allowing for highly flexible customization. For details on how to use those arguments, see `TODO: add reference`"
+    "Recall that faceting and aesthetics are independent mappings, allowing for highly flexible customization. For details on how to use those arguments, see the [PlotCollection API reference](https://arviz-plots.readthedocs.io/en/latest/api/generated/arviz_plots.PlotCollection.html).
+"
    ]
   },
   {


### PR DESCRIPTION
This PR replaces the TODO reference in the PlotCollection tutorial with a link to the PlotCollection API documentation.
Fixes #357.
