### PR TITLE
DOC: replace TODO with PlotCollection cross-reference

### DIFF
--- a/docs/source/tutorials/compose_own_plot.ipynb
+++ b/docs/source/tutorials/compose_own_plot.ipynb
@@ -1973,7 +1973,7 @@
    "id": "dd24d6b5-e60f-4bce-a569-da0ae39360c1",
    "metadata": {},
    "source": [
-    "Recall that faceting and aesthetics are independent mappings, allowing for highly flexible customization. For details on how to use those arguments, see `TODO: add reference`"
+    "Recall that faceting and aesthetics are independent mappings, allowing for highly flexible customization. For details on how to use those arguments, see the {class}`~arviz_plots.PlotCollection` API reference."
    ]
   },
   {
@@ -3088,9 +3088,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "arviz_1",
+   "display_name": "Python [conda env:base] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-base-py"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
This PR replaces the TODO reference in the PlotCollection tutorial with a proper MyST/Sphinx cross-reference to the PlotCollection API.

The notebook was edited using Jupyter to preserve valid JSON structure, and the reference avoids hard URLs so it works correctly across documentation versions.

Fixes #357.