### PR TITLE
Fix Plotly backend when color is unset

### DIFF
--- a/src/arviz_plots/backend/plotly/core.py
+++ b/src/arviz_plots/backend/plotly/core.py
@@ -111,6 +111,8 @@ def str_to_plotly_html(string):
 
 def combine_color_alpha(color, alpha=1):
     """Combine a color and alpha value into the equivalent rgba."""
+    if color is unset or alpha is unset:
+        return color
     if isinstance(color, str):
         if color.startswith("rgba("):
             warnings.warn("Found rgba color, value for `alpha` is ignored.")


### PR DESCRIPTION
This PR fixes errors in the Plotly backend when `color` is not explicitly provided.

`fill_between_y` and `multiple_lines` both call `combine_color_alpha`, which did not handle unset `color` or `alpha` values. This PR updates `combine_color_alpha` to return early when either input is unset, skipping the extra color processing in those cases. After this change, both functions work correctly without passing `color` or `alpha`, and Plotly falls back to its default color handling.

Manual testing:
- `fill_between_y` without `color` / `alpha`
- `multiple_lines` without `color` / `alpha`

Related to #371
