### PR TITLE
Fix trace plot xlabel text and add semantic test

### DIFF
--- a/src/arviz_plots/plots/trace_plot.py
+++ b/src/arviz_plots/plots/trace_plot.py
@@ -226,7 +226,7 @@ def plot_trace(
             **title_kwargs,
         )
 
-    # Add "Steps" as x_label for trace
+   # Add x-axis label for trace; default to sample dimension when available
     xlabel_kwargs = get_visual_kwargs(visuals, "xlabel")
     if xlabel_kwargs is not False:
         _, xlabel_aes, xlabel_ignore = filter_aes(
@@ -240,7 +240,7 @@ def plot_trace(
             labelled_x,
             "xlabel",
             ignore_aes=xlabel_ignore,
-            text="Steps" if xname is None else xname.capitalize(),
+            text="draw" if xname is None else xname,
             **xlabel_kwargs,
         )
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -788,6 +788,14 @@ class TestPlots:  # pylint: disable=too-many-public-methods
         assert "plot" in pc.viz.children
         assert pc.viz["trace"]["mu"].shape == (4,)
 
+    def test_plot_trace_xlabel_text(self, datatree, backend):
+        if backend != "none":
+            pytest.skip("Semantic xlabel text is only stored for backend='none'")
+        pc = plot_trace(datatree, backend=backend)
+        assert "xlabel" in pc.viz.children
+        xlabel_ds = pc.viz["xlabel"]["mu"]
+        assert xlabel_ds.item()["string"] == "draw"
+
     def test_plot_trace_sample(self, datatree_sample, backend):
         pc = plot_trace(datatree_sample, sample_dims="sample", backend=backend)
         assert "figure" in pc.viz.data_vars


### PR DESCRIPTION
### What this PR does
- Fixes the x-axis label text used by `plot_trace`
- Ensures the resolved xlabel text is semantically correct
- Adds a backend-safe test using `backend="none"`

### Why this change is needed
The previous xlabel handling could produce inconsistent or unintended text.
This PR makes the behavior explicit and adds a semantic test that does not
depend on rendering backends.

### Testing
- Added a new test restricted to `backend="none"`
- Other backends are skipped intentionally, as semantic metadata is not stored
  consistently across renderers
- `python -m pytest -k xlabel` passes locally