### PR TITLE
Docs: format bare URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@
 ArviZ plotting elements and static battery included plots
 
 We are currently working on splitting ArviZ into independent modules.
-See https://github.com/arviz-devs/arviz/issues/2088 for more details.
+See [arviz-devs/arviz#2088](https://github.com/arviz-devs/arviz/issues/2088) for more details.


### PR DESCRIPTION
Just a quick cleanup: converted the bare URL to a named link for better readability.

Doc-only change; no behavior change.