### PR TITLE
PlotCollection: Add _repr_html_ and _display_ methods

### DIFF
--- a/src/arviz_plots/plot_collection.py
+++ b/src/arviz_plots/plot_collection.py
@@ -270,11 +270,11 @@ class PlotCollection:
 
     def _repr_html_(self):
         if "figure" not in self.viz:
-            return repr(self)
+            return None
 
         fig = self.viz["figure"].item()
         if fig is None:
-            return repr(self)
+            return None
 
         return fig._repr_html_()  # pylint: disable=protected-access
 


### PR DESCRIPTION
Closes #427 

Just run a couple of manual checks, and the display method worked for the 3 backends on Marino.

I tried in Jupyter and JupyterLab, and the `_repr_html_` works for matplotlib (it already worked before this) and for plotly. For bokeh, we need something different, as we now get `GridPlot(id = 'p1083', …)`.