### PR TITLE
Fix [tool.pytest] -> [tool.pytest.ini_options] in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ disallow_untyped_defs = true
 # module = "thirdparty.*"
 # ignore_missing_imports = true
 
-[tool.pytest]
+[tool.pytest.ini_options]
 filterwarnings = ["error"]
 addopts = ["--strict-markers", "--durations=10"]
 markers = ["matplotlib", "bokeh", "plotly"]


### PR DESCRIPTION
`[tool.pytest]` is not a valid pytest section , pytest only reads from `[tool.pytest.ini_options]`. All pytest settings were being 
silently ignored. Confirmed with terminal evidence in Issue #458.

All tests pass with the fix applied.

Closes #458