### PR TITLE
Add nightlies to tox and fix Hypothesis test deadline Extended issue

### DIFF
--- a/src/arviz_plots/__init__.py
+++ b/src/arviz_plots/__init__.py
@@ -34,8 +34,11 @@ try:
     import matplotlib as mpl
 
     _arviz_style_path = os.path.join(os.path.dirname(__file__), "styles")
-    mplstyle.core.USER_LIBRARY_PATHS.append(_arviz_style_path)
-    mplstyle.core.reload_library()
+    if hasattr(mplstyle, "USER_LIBRARY_PATHS"):
+        mplstyle.USER_LIBRARY_PATHS.append(_arviz_style_path)
+    elif hasattr(mplstyle, "core") and hasattr(mplstyle.core, "USER_LIBRARY_PATHS"):
+        mplstyle.core.USER_LIBRARY_PATHS.append(_arviz_style_path)
+    mplstyle.reload_library()
 
     # adds perceptually uniform grey scale from colorcet
     _linear_grey_10_95_c0 = [

--- a/src/arviz_plots/__init__.py
+++ b/src/arviz_plots/__init__.py
@@ -36,7 +36,7 @@ try:
     _arviz_style_path = os.path.join(os.path.dirname(__file__), "styles")
     if hasattr(mplstyle, "USER_LIBRARY_PATHS"):
         mplstyle.USER_LIBRARY_PATHS.append(_arviz_style_path)
-    elif hasattr(mplstyle, "core") and hasattr(mplstyle.core, "USER_LIBRARY_PATHS"):
+    else:
         mplstyle.core.USER_LIBRARY_PATHS.append(_arviz_style_path)
     mplstyle.reload_library()
 

--- a/src/arviz_plots/backend/matplotlib/core.py
+++ b/src/arviz_plots/backend/matplotlib/core.py
@@ -39,7 +39,7 @@ class SquareRootScale(mscale.ScaleBase):
     name = "sqrt"
 
     def __init__(self, axis, **kwargs):  # pylint: disable=unused-argument
-        mscale.ScaleBase.__init__(self, axis)
+        mscale.ScaleBase.__init__(axis, self)
 
     def set_default_locators_and_formatters(self, axis):
         """Set the locators and formatters to default."""

--- a/src/arviz_plots/backend/matplotlib/core.py
+++ b/src/arviz_plots/backend/matplotlib/core.py
@@ -33,13 +33,10 @@ class UnsetDefault:
 unset = UnsetDefault()
 
 
-class SquareRootScale(mscale.ScaleBase):
+class SquareRootBaseScale(mscale.ScaleBase):
     """ScaleBase class for generating square root scale."""
 
     name = "sqrt"
-
-    def __init__(self, axis, **kwargs):  # pylint: disable=unused-argument
-        mscale.ScaleBase.__init__(axis, self)
 
     def set_default_locators_and_formatters(self, axis):
         """Set the locators and formatters to default."""
@@ -87,7 +84,25 @@ class SquareRootScale(mscale.ScaleBase):
         return self.SquareRootTransform()
 
 
-mscale.register_scale(SquareRootScale)
+class SquareRootScale(SquareRootBaseScale):
+    """ScaleBase class for generating square root scale for matplotlib<3.11."""
+
+    def __init__(self, axis):  # pylint: disable=all
+        super().__init__(axis)
+
+
+class SquareRootScale311(SquareRootBaseScale):
+    """ScaleBase class for generating square root scale for matplotlib>=3.11."""
+
+    def __init__(self):  # pylint: disable=all
+        pass
+
+
+try:
+    mscale.LinearScale()  # noqa
+    mscale.register_scale(SquareRootScale311)
+except TypeError:
+    mscale.register_scale(SquareRootScale)
 
 
 def get_background_color():
@@ -422,7 +437,7 @@ def scatter(
         "s": size,
         "marker": marker,
         "alpha": alpha,
-        "c": facecolor,
+        "color": facecolor,
         "edgecolors": edgecolor,
         "linewidths": width,
     }

--- a/src/arviz_plots/backend/matplotlib/core.py
+++ b/src/arviz_plots/backend/matplotlib/core.py
@@ -437,7 +437,7 @@ def scatter(
         "s": size,
         "marker": marker,
         "alpha": alpha,
-        "color": facecolor,
+        "c": facecolor,
         "edgecolors": edgecolor,
         "linewidths": width,
     }

--- a/src/arviz_plots/backend/matplotlib/core.py
+++ b/src/arviz_plots/backend/matplotlib/core.py
@@ -437,7 +437,7 @@ def scatter(
         "s": size,
         "marker": marker,
         "alpha": alpha,
-        "c": facecolor,
+        "color": facecolor,
         "edgecolors": edgecolor,
         "linewidths": width,
     }

--- a/src/arviz_plots/backend/none/core.py
+++ b/src/arviz_plots/backend/none/core.py
@@ -79,9 +79,11 @@ def get_default_aes(aes_key, n, kwargs=None):
         return np.array([f"C{i}" for i in range(n)])
     aes_vals = kwargs[aes_key]
     n_aes_vals = len(aes_vals)
+    aes_ary = np.empty(n_aes_vals, dtype=object)
+    aes_ary[:] = aes_vals
     if n_aes_vals >= n:
-        return aes_vals[:n]
-    return np.tile(aes_vals, (n // n_aes_vals) + 1)[:n]
+        return aes_ary[:n]
+    return np.tile(aes_ary, (n // n_aes_vals) + 1)[:n]
 
 
 def scale_fig_size(figsize, rows=1, cols=1, figsize_units=None):

--- a/src/arviz_plots/plot_collection.py
+++ b/src/arviz_plots/plot_collection.py
@@ -614,8 +614,8 @@ class PlotCollection:
                 neutral_element_needed = not all(aes_dims_in_var.values())
                 aes_vals = get_default_aes(aes_key, total_aes_vals + neutral_element_needed, kwargs)
                 if neutral_element_needed:
+                    ds_dict[aes_key]["neutral_element"] = xr.DataArray(aes_vals[[0]]).squeeze()
                     neutral_element = aes_vals[0]
-                    ds_dict[aes_key]["neutral_element"] = neutral_element
                     aes_vals_no_neutral = [val for val in aes_vals if val != neutral_element]
                     if aes_vals_no_neutral[0] in aes_vals_no_neutral[1:]:
                         cycle_repeat_index = aes_vals_no_neutral[1:].index(aes_vals_no_neutral[0])

--- a/tests/test_hypothesis_plots.py
+++ b/tests/test_hypothesis_plots.py
@@ -5,7 +5,7 @@ import hypothesis.strategies as st
 import numpy as np
 import pandas as pd
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 
 from arviz_plots import (
     combine_plots,
@@ -383,6 +383,7 @@ def test_plot_dgof(datatree, kind, envelope_prob, visuals):
     kind=kind_value_no_hist,
     envelope_prob=envelope_prob_value,
 )
+@settings(deadline=6000)
 def test_plot_dgof_dist(datatree, kind, envelope_prob, visuals):
     pc = plot_dgof_dist(
         datatree,

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 isolated_build = True
 isolated_build_env = build
 labels =
-    dev = check, cleandocs, docs, nogallerydocs, viewdocs, py311, py312, py313
+    dev = check, cleandocs, docs, nogallerydocs, viewdocs, py311, py312, py313,nightlies
 
 [gh-actions]
 python =
@@ -22,7 +22,7 @@ basepython =
     py311: python3.11
     py312: python3.12
     py313: python3.13
-    nightlies: python3.13
+    nightlies: python3
     # See https://github.com/tox-dev/tox/issues/1548
     {check,docs,cleandocs,viewdocs,build}: python3
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -22,9 +22,8 @@ basepython =
     py311: python3.11
     py312: python3.12
     py313: python3.13
-    nightlies: python3
-    # See https://github.com/tox-dev/tox/issues/1548
-    {check,docs,cleandocs,viewdocs,build}: python3
+# See https://github.com/tox-dev/tox/issues/1548
+{check,docs,cleandocs,viewdocs,build,nightlies}: python3
 setenv =
     PYTHONUNBUFFERED = yes
     PYTEST_EXTRA_ARGS = -s

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     check
     docs
+    nightlies
     {py312,py313,py314}{,-coverage}
 # See https://tox.readthedocs.io/en/latest/example/package.html#flit
 isolated_build = True
@@ -12,7 +13,7 @@ labels =
 [gh-actions]
 python =
     3.12: py312-coverage
-    3.13: check, py313-coverage
+    3.13: check, py313-coverage,nightlies
     3.14: py314-coverage
 
 [testenv]
@@ -21,6 +22,7 @@ basepython =
     py311: python3.11
     py312: python3.12
     py313: python3.13
+    nightlies: python3.13
     # See https://github.com/tox-dev/tox/issues/1548
     {check,docs,cleandocs,viewdocs,build}: python3
 setenv =
@@ -38,6 +40,14 @@ extras =
 commands =
     pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:}
 
+
+[testenv:nightlies]
+description = Run test job with nightly pre-releases of scientific python packages
+install_command = python -I -m pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple {opts} {packages}
+pip_pre = true
+setenv =
+  NIGHTLIES=TRUE
+  
 [testenv:check]
 description = Perform style checks
 deps =


### PR DESCRIPTION

### Description
This PR adds a `nightlies` test environment in `tox.ini` for arviz-plots.

### Key Implementation Details

- Added a nightlies environment in tox.ini.
- `hasattr` check for `mplstyle.USER_LIBRARY_PATHS` has been added for compatibility with newer versions.
- While testing, a `DeadlineExceeded` error was encountered in `tests/test_hypothesis_plots.py::test_plot_dgof_dist`. This was addressed by adding a `@settings(deadline=6000)` decorator to the affected test.

All tests passed locally.
Closes #453 