### PR TITLE
Refactor plot_ppc_pit

### DIFF
--- a/docs/source/gallery/sbc/00_plot_ecdf_pit.py
+++ b/docs/source/gallery/sbc/00_plot_ecdf_pit.py
@@ -27,7 +27,6 @@ azp.style.use("arviz-variat")
 data = load_arviz_data("sbc")
 pc = azp.plot_ecdf_pit(
     data,
-    method="envelope",
     backend="none"  # change to preferred backend
 )
 pc.show()

--- a/src/arviz_plots/backend/matplotlib/core.py
+++ b/src/arviz_plots/backend/matplotlib/core.py
@@ -470,6 +470,13 @@ def text(
     **artist_kws,
 ):
     """Interface to matplotlib for adding text to a plot."""
+    x = np.asarray(x)
+    if x.size == 1:
+        x = x.item()
+    y = np.asarray(y)
+    if y.size == 1:
+        y = y.item()
+
     kwargs = {
         "fontsize": size,
         "alpha": alpha,

--- a/src/arviz_plots/backend/plotly/core.py
+++ b/src/arviz_plots/backend/plotly/core.py
@@ -56,32 +56,22 @@ def apply_square_root_scale(plotly_plot, axis):
     row = plotly_plot.row
     col = plotly_plot.col
 
-    if not hasattr(figure.layout, "grid") or figure.layout.grid is None:
-        raise ValueError("The figure does not have a grid layout required for faceting.")
-
-    figure_grid = figure.layout.grid
-    num_cols = figure_grid.columns if figure_grid.columns is not None else 1
-    index = (row - 1) * num_cols + col
-    axis_ref = axis if index == 1 else f"{axis}{index}"
-    layout_axis = f"{axis}axis" if index == 1 else f"{axis}axis{index}"
-
     transformed_all = []
     original_all = []
 
-    for trace in figure.data:
-        if getattr(trace, f"{axis}axis", None) == axis_ref:
-            if hasattr(trace, axis) and getattr(trace, axis) is not None:
-                data = np.array(getattr(trace, axis), dtype=float)
-                data = np.maximum(data, 0.0)
-                transformed = np.sqrt(data)
-                trace.customdata = data.tolist()
-                setattr(trace, axis, transformed.tolist())
-                if axis == "y":
-                    trace.hovertemplate = "x: %{x:.2~g}<br>y: %{customdata:.2~g}<extra></extra>"
-                else:
-                    trace.hovertemplate = "x: %{customdata:.2~g}<br>y: %{y:.2~g}<extra></extra>"
-                transformed_all.extend(transformed)
-                original_all.extend(data)
+    for trace in figure.select_traces(row=row, col=col):
+        if hasattr(trace, axis) and getattr(trace, axis) is not None:
+            data = np.array(getattr(trace, axis), dtype=float)
+            data = np.maximum(data, 0.0)
+            transformed = np.sqrt(data)
+            trace.customdata = data.tolist()
+            setattr(trace, axis, transformed.tolist())
+            if axis == "y":
+                trace.hovertemplate = "x: %{x:.2~g}<br>y: %{customdata:.2~g}<extra></extra>"
+            else:
+                trace.hovertemplate = "x: %{customdata:.2~g}<br>y: %{y:.2~g}<extra></extra>"
+            transformed_all.extend(transformed)
+            original_all.extend(data)
 
     if not transformed_all:
         return
@@ -103,12 +93,15 @@ def apply_square_root_scale(plotly_plot, axis):
 
     ticktext_original = [f"{round(tv**2)}" for tv in tickvals_transformed]
 
-    figure.layout[layout_axis].update(
-        tickvals=tickvals_transformed,
-        ticktext=ticktext_original,
-        range=[min_val, max_val + 0.5],
-        title=figure.layout[layout_axis].title,
-    )
+    axis_kwargs = {
+        "tickvals": tickvals_transformed,
+        "ticktext": ticktext_original,
+        "range": [min_val, max_val + 0.5],
+    }
+    if axis == "y":
+        plotly_plot.update_yaxes(**axis_kwargs)
+    else:
+        plotly_plot.update_xaxes(**axis_kwargs)
 
 
 def str_to_plotly_html(string):

--- a/src/arviz_plots/plots/dgof_dist_plot.py
+++ b/src/arviz_plots/plots/dgof_dist_plot.py
@@ -31,7 +31,7 @@ def plot_dgof_dist(
     coords=None,
     sample_dims=None,
     kind=None,
-    method="envelope",
+    method="pot_c",
     envelope_prob=None,
     plot_collection=None,
     backend=None,

--- a/src/arviz_plots/plots/dgof_dist_plot.py
+++ b/src/arviz_plots/plots/dgof_dist_plot.py
@@ -128,6 +128,11 @@ def plot_dgof_dist(
     -------
     PlotCollection
 
+    See Also
+    --------
+    plot_dgof : Δ-ECDF-PIT diagnostic for 1D density estimation (kde, histogram, or quantile)
+    plot_dist : Plot 1D marginal distributions.
+
     Examples
     --------
     Default plot with quantile dot marginals and Δ-ECDF-PIT diagnostic:

--- a/src/arviz_plots/plots/dgof_plot.py
+++ b/src/arviz_plots/plots/dgof_plot.py
@@ -29,7 +29,7 @@ def plot_dgof(
     coords=None,
     sample_dims=None,
     kind=None,
-    method="envelope",
+    method="pot_c",
     envelope_prob=None,
     plot_collection=None,
     backend=None,

--- a/src/arviz_plots/plots/dgof_plot.py
+++ b/src/arviz_plots/plots/dgof_plot.py
@@ -123,6 +123,11 @@ def plot_dgof(
     -------
     PlotCollection
 
+    See Also
+    --------
+    plot_dgof_dist : Δ-ECDF-PIT diagnostic for 1D density estimation (kde, histogram, or quantile).
+    plot_dist : Plot 1D marginal distributions.
+
     Examples
     --------
     Δ-ECDF-PIT diagnostic for quantile dot marginals:

--- a/src/arviz_plots/plots/ecdf_plot.py
+++ b/src/arviz_plots/plots/ecdf_plot.py
@@ -1,4 +1,5 @@
 """Plot PIT Δ-ECDF."""
+import warnings
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal
@@ -44,7 +45,7 @@ def plot_ecdf_pit(
     group="prior_sbc",
     coords=None,
     sample_dims=None,
-    method="envelope",
+    method="pot_c",
     envelope_prob=None,
     coverage=False,
     plot_collection=None,
@@ -184,7 +185,7 @@ def plot_ecdf_pit(
         >>> style.use("arviz-variat")
         >>> from arviz_base import load_arviz_data
         >>> dt = load_arviz_data('sbc')
-        >>> plot_ecdf_pit(dt, method="envelope")
+        >>> plot_ecdf_pit(dt)
 
 
     .. minigallery:: plot_ecdf_pit
@@ -230,6 +231,12 @@ def plot_ecdf_pit(
     if method not in {"envelope", "pot_c", "prit_c", "piet_c"}:
         raise ValueError(
             f"Method {method} not supported. Choose from 'envelope', 'pot_c', 'prit_c' or 'piet_c'."
+        )
+    if method == "envelope":
+        warnings.warn(
+            "Method 'envelope' will be deprecated. As it assumes PIT values are independent.\n"
+            "Use 'pot_c' instead, which is valid for both independent and dependent PIT values.",
+            FutureWarning,
         )
 
     # ensure we have PIT values between 0 and 1.

--- a/src/arviz_plots/plots/loo_pit_plot.py
+++ b/src/arviz_plots/plots/loo_pit_plot.py
@@ -191,7 +191,8 @@ def plot_loo_pit(
             f"Method {method} not supported. Choose from 'envelope', 'pot_c', 'prit_c' or 'piet_c'."
         )
 
-    lpv = loo_pit(dt)
+    pareto_pit = method in ["pot_c", "piet_c"]
+    lpv = loo_pit(dt, pareto_pit=pareto_pit)
     new_dt = convert_to_datatree(lpv, group="loo_pit")
 
     visuals.setdefault("ylabel", {})

--- a/src/arviz_plots/plots/loo_pit_plot.py
+++ b/src/arviz_plots/plots/loo_pit_plot.py
@@ -60,8 +60,9 @@ def plot_loo_pit(
 
     This plot shows the empirical cumulative distribution function (ECDF) of the LOO-PIT values.
     To make the plot easier to interpret, we plot the Δ-ECDF, that is, the difference between the
-    observed ECDF and the expected CDF. Color code is used to indicate pointwise deviations from the
-    expected CDF.
+    observed ECDF and the expected CDF.
+    The points that contribute the most to deviations from uniformity are
+    computed as described in [3]_ and highlighted in the plot.
 
     Alternatively, we can visualize the coverage of the central posterior credible intervals by
     setting ``coverage=True``. This allows us to assess whether the credible intervals includes
@@ -94,8 +95,8 @@ def plot_loo_pit(
         Defaults to ``rcParams["data.sample_dims"]``
         CURRENTLY NOT SUPPORTED
     method : {"pot_c", "prit_c", "piet_c"}, optional
-        Method to compute the simultaneous confidence bands for the Δ-ECDF-PIT diagnostic.
-        Defaults to "pot_c". Check the documentation of :func:`~arviz_plots.plot_ecdf_pit` for
+        Method to use for the uniformity test. Defaults to "pot_c".
+        Check the documentation of :func:`~arviz_plots.plot_ecdf_pit` for
         more details.
     envelope_prob : float, optional
         Indicates the probability threshold to highlight points.

--- a/src/arviz_plots/plots/loo_pit_plot.py
+++ b/src/arviz_plots/plots/loo_pit_plot.py
@@ -133,6 +133,11 @@ def plot_loo_pit(
     -------
     PlotCollection
 
+    See Also
+    --------
+    plot_ppc_pit : Predictive check using PIT Δ-ECDF uniformity test.
+    plot_loo_interval : Predictive intervals and observed data.
+
     Examples
     --------
     Plot the ecdf-PIT for the crabs hurdle-negative-binomial dataset.

--- a/src/arviz_plots/plots/ppc_pit_plot.py
+++ b/src/arviz_plots/plots/ppc_pit_plot.py
@@ -143,6 +143,13 @@ def plot_ppc_pit(
     -------
     PlotCollection
 
+    See Also
+    --------
+    plot_loo_pit : Predictive check using LOO-PIT Δ-ECDF uniformity test.
+    plot_ppc_dist :  Predictive check using 1D marginals for predictive (and observed data).
+    plot_ppc_pava : Predictive check ideal for binary, ordinal or categorical data.
+    plot_ppc_rootogram : Predictive check ideal for discrete (count) data.
+
     Examples
     --------
     Plot the ecdf-PIT for the crabs hurdle-negative-binomial dataset.
@@ -247,14 +254,13 @@ def _ppc_pit(predictive_dist, observed_dist, sample_dims, coverage, pareto_pit):
     for var in observed_dist.data_vars:
         if pareto_pit:
             pred_stacked = predictive_dist[var].stack(__sample__=sample_dims)
-
             vals = xr.apply_ufunc(
-                array_stats._pareto_pit,  # pylint: disable=protected-access
+                array_stats._pareto_pit_vec,  # pylint: disable=protected-access
                 pred_stacked,
                 observed_dist[var],
                 input_core_dims=[["__sample__"], []],
                 output_core_dims=[[]],
-                vectorize=True,
+                vectorize=False,
                 kwargs={"rng": rng},
             )
         else:

--- a/src/arviz_plots/plots/ppc_pit_plot.py
+++ b/src/arviz_plots/plots/ppc_pit_plot.py
@@ -2,12 +2,14 @@
 from collections.abc import Mapping, Sequence
 from typing import Any, Literal
 
+import numpy as np
 import xarray as xr
 from arviz_base.validate import (
     validate_dict_argument,
     validate_or_use_rcparam,
     validate_sample_dims,
 )
+from arviz_stats.base.array import array_stats
 
 from arviz_plots.plots import plot_ecdf_pit
 from arviz_plots.plots.utils import process_group_variables_coords
@@ -184,12 +186,14 @@ def plot_ppc_pit(
     warn_if_binary(observed_dist, predictive_dist)
     warn_if_prior_predictive(group)
 
-    new_dt = _ppc_pit(predictive_dist, observed_dist, sample_dims, coverage)
-
     if method not in {"envelope", "pot_c", "prit_c", "piet_c"}:
         raise ValueError(
             f"Method {method} not supported. Choose from 'envelope', 'pot_c', 'prit_c' or 'piet_c'."
         )
+
+    pareto_pit = method in ["pot_c", "piet_c"]
+
+    new_dt = _ppc_pit(predictive_dist, observed_dist, sample_dims, coverage, pareto_pit)
 
     visuals.setdefault("ylabel", {})
     visuals.setdefault("remove_axis", False)
@@ -217,11 +221,12 @@ def plot_ppc_pit(
     return plot_collection
 
 
-def _ppc_pit(predictive_dist, observed_dist, sample_dims, coverage):
-    """Compute the difference PIT ECDF values.
+def _ppc_pit(predictive_dist, observed_dist, sample_dims, coverage, pareto_pit):
+    """Compute Pareto-smoothed PIT ECDF values.
 
-    The probability of the posterior predictive being less than or equal to the observed data.
-    should be uniformly distributed. This function computes the PIT ECDF.
+    The probability of the posterior predictive being less than or equal to the observed data
+    should be uniformly distributed. This function computes the PIT values with
+    Generalized Pareto Distribution tail refinement.
 
     Parameters
     ----------
@@ -233,17 +238,30 @@ def _ppc_pit(predictive_dist, observed_dist, sample_dims, coverage):
         Dimensions to reduce.
     coverage : bool
         Whether to compute the coverage.
+    pareto_pit : bool
+        Whether to use Pareto-smoothed PIT values.
     """
-    import numpy as np
-
     rng = np.random.default_rng(214)
 
     dictio = {}
     for var in observed_dist.data_vars:
-        vals_less = (predictive_dist[var] < observed_dist[var]).mean(sample_dims)
-        vals_eq = (predictive_dist[var] == observed_dist[var]).mean(sample_dims)
-        urvs = rng.uniform(size=vals_less.values.shape)
-        vals = vals_less + urvs * vals_eq
+        if pareto_pit:
+            pred_stacked = predictive_dist[var].stack(__sample__=sample_dims)
+
+            vals = xr.apply_ufunc(
+                array_stats._pareto_pit,  # pylint: disable=protected-access
+                pred_stacked,
+                observed_dist[var],
+                input_core_dims=[["__sample__"], []],
+                output_core_dims=[[]],
+                vectorize=True,
+                kwargs={"rng": rng},
+            )
+        else:
+            vals_less = (predictive_dist[var] < observed_dist[var]).mean(sample_dims)
+            vals_eq = (predictive_dist[var] == observed_dist[var]).mean(sample_dims)
+            urvs = rng.uniform(size=vals_less.values.shape)
+            vals = vals_less + urvs * vals_eq
 
         if coverage:
             vals = 2 * np.abs(vals - 0.5)

--- a/src/arviz_plots/plots/ppc_pit_plot.py
+++ b/src/arviz_plots/plots/ppc_pit_plot.py
@@ -1,34 +1,17 @@
 """Plot ppc pit."""
 from collections.abc import Mapping, Sequence
-from importlib import import_module
 from typing import Any, Literal
 
 import xarray as xr
-from arviz_base import rcParams
-from arviz_base.labels import BaseLabeller
 from arviz_base.validate import (
     validate_dict_argument,
     validate_or_use_rcparam,
     validate_sample_dims,
 )
-from arviz_stats.ecdf_utils import difference_ecdf_pit
 
-from arviz_plots.plot_collection import PlotCollection
-from arviz_plots.plots.utils import (
-    filter_aes,
-    get_visual_kwargs,
-    process_group_variables_coords,
-    set_wrap_layout,
-)
+from arviz_plots.plots import plot_ecdf_pit
+from arviz_plots.plots.utils import process_group_variables_coords
 from arviz_plots.plots.utils_plot_types import warn_if_binary, warn_if_prior_predictive
-from arviz_plots.visuals import (
-    ecdf_line,
-    fill_between_y,
-    labelled_title,
-    labelled_x,
-    labelled_y,
-    set_xticks,
-)
 
 
 def plot_ppc_pit(
@@ -39,6 +22,7 @@ def plot_ppc_pit(
     group="posterior_predictive",
     coords=None,
     sample_dims=None,
+    method="pot_c",
     envelope_prob=None,
     coverage=False,
     plot_collection=None,
@@ -48,8 +32,10 @@ def plot_ppc_pit(
         Literal[
             "ecdf_lines",
             "credible_interval",
+            "suspicious_points",
+            "p_value_text",
             "xlabel",
-            "xlabel",
+            "ylabel",
             "title",
         ],
         Sequence[str],
@@ -58,9 +44,12 @@ def plot_ppc_pit(
         Literal[
             "ecdf_lines",
             "credible_interval",
+            "suspicious_points",
+            "p_value_text",
             "xlabel",
             "ylabel",
             "title",
+            "remove_axis",
         ],
         Mapping[str, Any] | bool,
     ] = None,
@@ -76,8 +65,9 @@ def plot_ppc_pit(
 
     This plot shows the empirical cumulative distribution function (ECDF) of the PIT values.
     To make the plot easier to interpret, we plot the Δ-ECDF, that is, the difference between
-    the observed ECDF and the expected CDF. Simultaneous confidence bands are computed using
-    the method described in described in [1]_.
+    the observed ECDF and the expected CDF.
+    The points that contribute the most to deviations from uniformity are
+    computed as described in [1]_ and highlighted in the plot.
 
     Alternatively, we can visualize the coverage of the central posterior credible intervals by
     setting ``coverage=True``. This allows us to assess whether the credible intervals includes
@@ -106,6 +96,10 @@ def plot_ppc_pit(
     sample_dims : str or sequence of hashable, optional
         Dimensions to reduce unless mapped to an aesthetic.
         Defaults to ``rcParams["data.sample_dims"]``
+    method : {"pot_c", "prit_c", "piet_c", "envelope"}, optional
+        Method to use for the uniformity test. Defaults to "pot_c".
+        Check the documentation of :func:`~arviz_plots.plot_ecdf_pit` for
+        more details.
     envelope_prob : float, optional
         Indicates the probability that should be contained within the envelope.
         Defaults to ``rcParams["stats.envelope_prob"]``.
@@ -122,10 +116,16 @@ def plot_ppc_pit(
         Valid keys are:
 
         * ecdf_lines -> passed to :func:`~arviz_plots.visuals.ecdf_line`
-        * credible_interval -> passed to :func:`~arviz_plots.visuals.fill_between_y`
+        * credible_interval -> passed to :func:`~arviz_plots.visuals.fill_between_y`,
+          only when method is "envelope"
+        * ref_line -> passed to :func:`~arviz_plots.visuals.line_xy`
+        * suspicious_points -> passed to :func:`~arviz_plots.visuals.scatter_xy`
+        * p_value_text -> passed to :func:`~arviz_plots.visuals.annotate_xy`
+          only when method is not "envelope"
         * xlabel -> passed to :func:`~arviz_plots.visuals.labelled_x`
         * ylabel -> passed to :func:`~arviz_plots.visuals.labelled_y`
         * title -> passed to :func:`~arviz_plots.visuals.labelled_title`
+        * remove_axis -> not passed anywhere, can only be ``False`` to skip calling this function
 
     stats : mapping, optional
         Valid keys are:
@@ -166,26 +166,12 @@ def plot_ppc_pit(
 
     References
     ----------
-    .. [1] Säilynoja et al. *Graphical test for discrete uniformity and
-       its applications in goodness-of-fit evaluation and multiple sample comparison*.
-       Statistics and Computing 32(32). (2022) https://doi.org/10.1007/s11222-022-10090-6
+    .. [1] Tasso et al. *LOO-PIT predictive model checking* arXiv:2603.02928 (2026).
     """
     envelope_prob = validate_or_use_rcparam(envelope_prob, "stats.envelope_prob")
     aes_by_visuals = validate_dict_argument(aes_by_visuals, (plot_ppc_pit, "aes_by_visuals"))
     visuals = validate_dict_argument(visuals, (plot_ppc_pit, "visuals"))
     stats = validate_dict_argument(stats, (plot_ppc_pit, "stats"))
-
-    ecdf_pit_kwargs = stats.get("ecdf_pit", {}).copy()
-    ecdf_pit_kwargs.setdefault("n_simulations", 1000)
-
-    if backend is None:
-        if plot_collection is None:
-            backend = rcParams["plot.backend"]
-        else:
-            backend = plot_collection.backend
-
-    if labeller is None:
-        labeller = BaseLabeller()
 
     predictive_dist = process_group_variables_coords(
         dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords
@@ -198,122 +184,70 @@ def plot_ppc_pit(
     warn_if_binary(observed_dist, predictive_dist)
     warn_if_prior_predictive(group)
 
-    ds_ecdf = difference_ecdf_pit(
-        predictive_dist, observed_dist, envelope_prob, coverage, **ecdf_pit_kwargs
+    new_dt = _ppc_pit(predictive_dist, observed_dist, sample_dims, coverage)
+
+    if method not in {"envelope", "pot_c", "prit_c", "piet_c"}:
+        raise ValueError(
+            f"Method {method} not supported. Choose from 'envelope', 'pot_c', 'prit_c' or 'piet_c'."
+        )
+
+    visuals.setdefault("ylabel", {})
+    visuals.setdefault("remove_axis", False)
+    visuals.setdefault("xlabel", {"text": "ETI %" if coverage else "PIT"})
+
+    plot_collection = plot_ecdf_pit(
+        new_dt,
+        var_names=var_names,
+        filter_vars=filter_vars,
+        group="ecdf_pit",
+        coords=coords,
+        sample_dims=new_dt.ecdf_pit.dims,
+        method=method,
+        envelope_prob=envelope_prob,
+        coverage=coverage,
+        plot_collection=plot_collection,
+        backend=backend,
+        labeller=labeller,
+        aes_by_visuals=aes_by_visuals,
+        visuals=visuals,
+        stats=stats,
+        **pc_kwargs,
     )
-
-    plot_bknd = import_module(f".backend.{backend}", package="arviz_plots")
-
-    if plot_collection is None:
-        pc_kwargs["figure_kwargs"] = pc_kwargs.get("figure_kwargs", {}).copy()
-        pc_kwargs["figure_kwargs"].setdefault("sharex", True)
-        pc_kwargs["aes"] = pc_kwargs.get("aes", {}).copy()
-        pc_kwargs.setdefault("cols", "__variable__")
-
-        pc_kwargs = set_wrap_layout(pc_kwargs, plot_bknd, ds_ecdf)
-
-        plot_collection = PlotCollection.wrap(
-            ds_ecdf,
-            backend=backend,
-            **pc_kwargs,
-        )
-
-    ## ecdf_line
-    ecdf_ls_kwargs = get_visual_kwargs(visuals, "ecdf_lines")
-
-    if ecdf_ls_kwargs is not False:
-        _, _, ecdf_ls_ignore = filter_aes(
-            plot_collection, aes_by_visuals, "ecdf_lines", sample_dims
-        )
-        ecdf_ls_kwargs.setdefault("color", "C0")
-
-        plot_collection.map(
-            ecdf_line,
-            "ecdf_lines",
-            data=ds_ecdf,
-            ignore_aes=ecdf_ls_ignore,
-            **ecdf_ls_kwargs,
-        )
-
-    if coverage:
-        plot_collection.map(
-            set_xticks,
-            "ecdf_xticks",
-            values=[0, 0.25, 0.5, 0.75, 1],
-            labels=["0", "25", "50", "75", "100"],
-            store_artist=backend == "none",
-        )
-
-    ci_kwargs = get_visual_kwargs(visuals, "credible_interval")
-    _, _, ci_ignore = filter_aes(plot_collection, aes_by_visuals, "credible_interval", sample_dims)
-    if ci_kwargs is not False:
-        ci_kwargs.setdefault("color", "B1")
-        ci_kwargs.setdefault("alpha", 0.1)
-
-        plot_collection.map(
-            fill_between_y,
-            "credible_interval",
-            data=ds_ecdf,
-            x=ds_ecdf.sel(plot_axis="x"),
-            y_bottom=ds_ecdf.sel(plot_axis="y_bottom"),
-            y_top=ds_ecdf.sel(plot_axis="y_top"),
-            ignore_aes=ci_ignore,
-            **ci_kwargs,
-        )
-
-    # set xlabel
-    _, xlabels_aes, xlabels_ignore = filter_aes(
-        plot_collection, aes_by_visuals, "xlabel", sample_dims
-    )
-    xlabel_kwargs = get_visual_kwargs(visuals, "xlabel")
-    if xlabel_kwargs is not False:
-        if "color" not in xlabels_aes:
-            xlabel_kwargs.setdefault("color", "B1")
-
-        if coverage:
-            xlabel_kwargs.setdefault("text", "ETI %")
-        else:
-            xlabel_kwargs.setdefault("text", "PIT")
-
-        plot_collection.map(
-            labelled_x,
-            "xlabel",
-            ignore_aes=xlabels_ignore,
-            subset_info=True,
-            **xlabel_kwargs,
-        )
-
-    # set ylabel
-    _, ylabels_aes, ylabels_ignore = filter_aes(
-        plot_collection, aes_by_visuals, "ylabel", sample_dims
-    )
-    ylabel_kwargs = get_visual_kwargs(visuals, "ylabel")
-    if ylabel_kwargs is not False:
-        if "color" not in ylabels_aes:
-            ylabel_kwargs.setdefault("color", "B1")
-
-        ylabel_kwargs.setdefault("text", "Δ ECDF")
-
-        plot_collection.map(
-            labelled_y,
-            "ylabel",
-            ignore_aes=ylabels_ignore,
-            subset_info=True,
-            **ylabel_kwargs,
-        )
-
-    # title
-    title_kwargs = get_visual_kwargs(visuals, "title")
-    _, _, title_ignore = filter_aes(plot_collection, aes_by_visuals, "title", sample_dims)
-
-    if title_kwargs is not False:
-        plot_collection.map(
-            labelled_title,
-            "title",
-            ignore_aes=title_ignore,
-            subset_info=True,
-            labeller=labeller,
-            **title_kwargs,
-        )
 
     return plot_collection
+
+
+def _ppc_pit(predictive_dist, observed_dist, sample_dims, coverage):
+    """Compute the difference PIT ECDF values.
+
+    The probability of the posterior predictive being less than or equal to the observed data.
+    should be uniformly distributed. This function computes the PIT ECDF.
+
+    Parameters
+    ----------
+    predictive_dist : xarray.Dataset
+        The posterior predictive distribution.
+    observed_dist : xarray.Dataset
+        The observed data.
+    sample_dims : str or sequence of hashable, optional
+        Dimensions to reduce.
+    coverage : bool
+        Whether to compute the coverage.
+    """
+    import numpy as np
+
+    rng = np.random.default_rng(214)
+
+    dictio = {}
+    for var in observed_dist.data_vars:
+        vals_less = (predictive_dist[var] < observed_dist[var]).mean(sample_dims)
+        vals_eq = (predictive_dist[var] == observed_dist[var]).mean(sample_dims)
+        urvs = rng.uniform(size=vals_less.values.shape)
+        vals = vals_less + urvs * vals_eq
+
+        if coverage:
+            vals = 2 * np.abs(vals - 0.5)
+
+        dictio[var] = vals
+
+    return xr.DataTree.from_dict({"ecdf_pit": xr.Dataset(dictio)})

--- a/tests/test_hypothesis_plots.py
+++ b/tests/test_hypothesis_plots.py
@@ -125,7 +125,6 @@ def compare_df_strategy(draw):
         optional={
             "lines": visuals_value,
             "ref_line": visuals_value,
-            "credible_interval": visuals_value,
             "xlabel": visuals_value,
             "title": visuals_value,
         },
@@ -309,7 +308,6 @@ def test_plot_dist(datatree, kind, ci_kind, point_estimate, visuals):
         {},
         optional={
             "ecdf_lines": visuals_value,
-            "credible_interval": visuals_value,
             "title": visuals_value,
             "xlabel": visuals_value,
             "ylabel": visuals_value,
@@ -343,7 +341,6 @@ def test_plot_dgof(datatree, kind, envelope_prob, visuals):
         optional={
             "dist": visuals_value,
             "ecdf_lines": visuals_value,
-            "credible_interval": visuals_value,
             "title": visuals_value,
             "xlabel": visuals_value,
             "ylabel": visuals_value,
@@ -409,7 +406,6 @@ def test_plot_energy(datatree, kind, visuals, show_bfmi):
         {},
         optional={
             "ecdf_lines": visuals_value,
-            "credible_interval": visuals_value,
             "xlabel": visuals_value,
             "ylabel": visuals_value,
             "title": visuals_value,
@@ -1036,7 +1032,6 @@ def test_plot_ppc_rootogram(datatree3, ci_prob, visuals):
         {},
         optional={
             "ecdf_lines": visuals_value,
-            "credible_interval": visuals_value,
             "xlabel": visuals_value,
             "ylabel": visuals_value,
             "title": visuals_value,
@@ -1071,7 +1066,6 @@ def test_plot_ppc_pit(datatree, coverage, envelope_prob, visuals):
         optional={
             "dist": visuals_value_no_false,
             "observed_tstat": visuals_value,
-            "credible_interval": visuals_value,
             "point_estimate": visuals_value,
             "point_estimate_text": visuals_value,
             "title": visuals_value,

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -105,7 +105,7 @@ class TestPlots:  # pylint: disable=too-many-public-methods
         pc = plot_dgof(datatree, backend=backend, kind=kind)
         assert not pc.aes
         assert "mu" in pc.viz["ecdf_lines"].data_vars
-        visuals = ("plot", "credible_interval", "ecdf_lines")
+        visuals = ("plot", "ecdf_lines")
         assert "ecdf_lines" in pc.viz.children
         assert all("hierarchy" not in pc.viz[visual]["mu"].dims for visual in visuals)
         assert all("hierarchy" in pc.viz[visual]["theta"].dims for visual in visuals)
@@ -115,7 +115,7 @@ class TestPlots:  # pylint: disable=too-many-public-methods
         pc = plot_dgof_dist(datatree, backend=backend, kind=kind)
         assert not pc.aes
         assert "mu" in pc.viz["dist"].data_vars
-        visuals = ("plot", "dist", "credible_interval", "ecdf_lines")
+        visuals = ("plot", "dist", "ecdf_lines")
         assert "dist" in pc.viz.children
         assert all("hierarchy" not in pc.viz[visual]["mu"].dims for visual in visuals)
         assert all("hierarchy" in pc.viz[visual]["theta"].dims for visual in visuals)


### PR DESCRIPTION
Reduce redundant code in `plot_ppc_dist` by calling `plot_ecdf_pit`. 
Add a deprecation message about the envelope method.
Fix a couple of issues not directly related to these changes, but that I noticed while working on this refactor.
Use `pareto_pit` depends on https://github.com/arviz-devs/arviz-stats/pull/353

