### PR TITLE
Add tests for combine_plots

### DIFF
--- a/tests/test_hypothesis_plots.py
+++ b/tests/test_hypothesis_plots.py
@@ -8,6 +8,7 @@ import pytest
 from hypothesis import given
 
 from arviz_plots import (
+    combine_plots,
     plot_autocorr,
     plot_bf,
     plot_compare,
@@ -208,6 +209,37 @@ def test_plot_compare(cmp_df, relative_scale, rotated, hide_top_model, visuals):
     for visual, value in visuals.items():
         if value is False:
             assert visual not in pc.viz.data_vars
+
+
+plot_options = st.sampled_from(
+    [
+        (plot_dist, {}),
+        (plot_autocorr, {}),
+    ]
+)
+
+
+@given(
+    expand=st.sampled_from(("column", "row")),
+    random_plots=st.lists(plot_options, min_size=1, max_size=3),
+)
+def test_combine_plots(datatree, expand, random_plots):
+    plot_names = [f"{plot.__name__}_{idx:02d}" for idx, (plot, _) in enumerate(random_plots)]
+    pc = combine_plots(
+        datatree,
+        plots=random_plots,
+        backend="none",
+        expand=expand,
+        var_names=["mu"],
+    )
+    assert "figure" in pc.viz.data_vars
+    assert expand in pc.viz.dims
+    assert len(pc.viz.coords[expand]) == len(random_plots)
+    assert list(pc.viz.coords[expand].values) == plot_names
+    assert all(
+        any(child_name.endswith(f"_{plot_name}") for child_name in pc.viz.children)
+        for plot_name in plot_names
+    )
 
 
 @pytest.mark.filterwarnings("ignore:nquantiles .* must be .*number of data points.*;using")

--- a/tests/test_hypothesis_plots.py
+++ b/tests/test_hypothesis_plots.py
@@ -233,9 +233,9 @@ def test_combine_plots(datatree, expand, random_plots):
         var_names=["mu"],
     )
     assert "figure" in pc.viz.data_vars
-    assert expand in pc.viz.dims
-    assert len(pc.viz.coords[expand]) == len(random_plots)
-    assert list(pc.viz.coords[expand].values) == plot_names
+    assert expand in pc.viz["plot"].dims
+    assert len(pc.viz["plot"].coords[expand]) == len(random_plots)
+    assert list(pc.viz["plot"].coords[expand].values) == plot_names
     assert all(
         any(child_name.endswith(f"_{plot_name}") for child_name in pc.viz.children)
         for plot_name in plot_names

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -7,6 +7,7 @@ from arviz_plots import (
     PlotCollection,
     add_bands,
     add_lines,
+    combine_plots,
     plot_autocorr,
     plot_bf,
     plot_compare,
@@ -93,6 +94,50 @@ class TestPlots:  # pylint: disable=too-many-public-methods
             backend=backend,
         )
         assert "plot" in pc.viz.data_vars
+
+    def test_combine_plots(self, datatree, backend):
+        pc = combine_plots(
+            datatree,
+            plots=[
+                (plot_dist, {}),
+                (plot_autocorr, {}),
+            ],
+            var_names=["mu"],
+            backend=backend,
+        )
+        assert "figure" in pc.viz.data_vars
+
+    def test_combine_plots_expand_row(self, datatree, backend):
+        pc = combine_plots(
+            datatree,
+            plots=[
+                (plot_dist, {}),
+                (plot_autocorr, {}),
+            ],
+            expand="row",
+            var_names=["mu"],
+            backend=backend,
+        )
+        assert "figure" in pc.viz.data_vars
+
+    def test_combine_plots_plot_names(self, datatree, backend):
+        pc = combine_plots(
+            datatree,
+            plots=[
+                (plot_dist, {}),
+                (plot_autocorr, {}),
+            ],
+            plot_names=["distribution", "autocorrelation"],
+            var_names=["mu"],
+            backend=backend,
+        )
+        assert "figure" in pc.viz.data_vars
+        assert "column" in pc.viz.dims
+        assert list(pc.viz.coords["column"].values) == ["distribution", "autocorrelation"]
+
+    def test_combine_plots_invalid_expand(self, datatree, backend):
+        with pytest.raises(ValueError, match="must be 'row' or 'column'"):
+            combine_plots(datatree, plots=[(plot_dist, {})], backend=backend, expand="diagonal")
 
     def test_plot_convergence_dist(self, datatree, backend):
         pc = plot_convergence_dist(datatree, backend=backend)

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -132,8 +132,11 @@ class TestPlots:  # pylint: disable=too-many-public-methods
             backend=backend,
         )
         assert "figure" in pc.viz.data_vars
-        assert "column" in pc.viz.dims
-        assert list(pc.viz.coords["column"].values) == ["distribution", "autocorrelation"]
+        assert "column" in pc.viz["plot"].dims
+        assert list(pc.viz["plot"].coords["column"].values) == [
+            "distribution",
+            "autocorrelation",
+        ]
 
     def test_combine_plots_invalid_expand(self, datatree, backend):
         with pytest.raises(ValueError, match="must be 'row' or 'column'"):


### PR DESCRIPTION
Address issue https://github.com/arviz-devs/arviz-plots/issues/63

This PR adds the missing test coverage for the `combine_plots` function. I have included both unit tests and a Hypothesis test.

- Added standard unit tests for row/column layouts and custom names.
- Added a `ValueError` check for invalid `expand` arguments.
- Added a Hypothesis test to check different plot combinations.