### PR TITLE
Handle mixed dims and MultiIndex warnings

### DIFF
--- a/src/arviz_plots/plot_collection.py
+++ b/src/arviz_plots/plot_collection.py
@@ -1067,9 +1067,7 @@ class PlotCollection:
             artist_dims = {}
         if dim_to_idx is None:
             dim_to_idx = {}
-        artist_dt = xr.DataTree()
-        if ignore_aes:
-            artist_dt.attrs = {"ignore_aes": ignore_aes}
+        artist_das = []
         for var_name, da in data.items():
             inherited_dims = [
                 dim_to_idx.get(dim, dim)
@@ -1082,8 +1080,7 @@ class PlotCollection:
             ] + list(artist_dims.values())
             all_artist_dims = inherited_dims + list(artist_dims.keys())
 
-            # TODO: once DataTree has a .loc attribute, this should work on .viz instead
-            artist_dt[var_name] = xr.DataArray(
+            out_da = xr.DataArray(
                 np.full(artist_shape, None, dtype=object),
                 dims=all_artist_dims,
                 coords={
@@ -1091,6 +1088,15 @@ class PlotCollection:
                     for dim in inherited_dims
                 },
             )
+            out_da.name = var_name
+            artist_das.append(out_da)
+
+        artist_ds = (
+            xr.merge(artist_das, compat="override", join="outer") if artist_das else xr.Dataset()
+        )
+        artist_dt = xr.DataTree(artist_ds)
+        if ignore_aes:
+            artist_dt.attrs = {"ignore_aes": ignore_aes}
         if func_label in self._viz_dt.children:
             for var_name, da in artist_dt.items():
                 self._viz_dt[func_label][var_name] = da

--- a/src/arviz_plots/plots/utils.py
+++ b/src/arviz_plots/plots/utils.py
@@ -240,6 +240,7 @@ def _compute_func_da(func, da, active_dims, reduce_dims, kwargs=None):
         )
     if groupby_dims:
         da = da.groupby(groupby_dims)
+    reduce_dims = [dim for dim in reduce_dims if dim in da.dims]
     with warnings.catch_warnings():
         if "model" in da.dims:
             warnings.filterwarnings("ignore", message="Your data appears to have a single")
@@ -251,14 +252,18 @@ def _compute_func_da(func, da, active_dims, reduce_dims, kwargs=None):
 
 def _compute_func(func, data, active_dims, reduce_dims, var_names=None, kwargs=None):
     """Compute given function for taking into account active and dimensions to reduce."""
-    viz_out = xr.Dataset()
     if var_names is None:
         var_names = data.data_vars
+    out_das = []
     for var_name in var_names:
-        viz_out[var_name] = _compute_func_da(
+        out_da = _compute_func_da(
             func, data[var_name], active_dims=active_dims, reduce_dims=reduce_dims, kwargs=kwargs
         )
-    return viz_out
+        out_da.name = var_name
+        out_das.append(out_da)
+    if not out_das:
+        return xr.Dataset()
+    return xr.merge(out_das, compat="override", join="outer")
 
 
 def compute_dist(data, reduce_dims, active_dims, kind=None, stats=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import arviz_plots.backend.none as none_backend
 from arviz_plots import PlotCollection
 from arviz_plots.plots.utils import (
     annotate_bin_text,
+    compute_dist,
     filter_aes,
     format_coords_as_labels,
     get_group,
@@ -240,3 +241,32 @@ class TestUtils:
         )
 
         assert result["string"] == "0 (0.0%)"
+
+    def test_compute_dist_handles_mixed_variable_dims(self):
+        """Test compute_dist handles mixed variable dimensions."""
+        sample = 30
+        obs = 4
+        ds = xr.Dataset(
+            {
+                "y_obs": xr.DataArray(
+                    np.random.default_rng(0).normal(size=(sample, obs)),
+                    dims=("sample", "obs"),
+                ),
+                "y_scalar": xr.DataArray(
+                    np.random.default_rng(1).normal(size=sample),
+                    dims=("sample",),
+                ),
+            }
+        )
+
+        density = compute_dist(
+            ds,
+            reduce_dims=["sample", "obs"],
+            active_dims=[],
+            kind="kde",
+            stats={},
+        )
+
+        assert set(density.data_vars) == {"y_obs", "y_scalar"}
+        assert density["y_obs"].attrs["kind"] == "kde"
+        assert density["y_scalar"].attrs["kind"] == "kde"


### PR DESCRIPTION
I got a `ValueError: tuple.index(x): x not in tuple` when running this example from EABM. I realized now I already saw this problem when running an example from PyMC docs, but then I completely forgot about it.

```python
observed = pz.Normal(0, 1).rvs(500)

predictions = {}
for i, (mu, sigma) in enumerate([
                                (0.5, 1),  # shifted to the right
                                (-0.5, 1), # shifted to the left
                                (0, 2),    # wider 
                                (0, 0.5),  # narrower
                                ]):
    predictions[f"y{i}"] =  pz.Normal(mu, sigma).rvs((4, 500, 100))

dt_i = az.from_dict({
    "posterior_predictive":predictions,
    "observed_data": {f"y{i}": observed for i in range(len(predictions))}
})

az.plot_ppc_dist(dt_i,
                  kind="kde",  
                  visuals={"remove_axis":False},
                 );
```

This PR fixes that issue and also fixes a `FutureWarning: Deleting a single level of a MultiIndex is deprecated. ` 