### PR TITLE
Add ppc_dist_pit and refactor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     exclude: ^src/arviz_base/example_data/
 
 - repo: https://github.com/psf/black
-  rev: 23.3.0
+  rev: 24.10.0
   hooks:
   - id: black
     exclude: ^docs/source/gallery/

--- a/docs/source/api/plots.rst
+++ b/docs/source/api/plots.rst
@@ -40,6 +40,7 @@ A complementary introduction and guide to ``plot_...`` functions is available at
    plot_parallel
    plot_ppc_censored
    plot_ppc_dist
+   plot_ppc_dist_pit
    plot_ppc_interval
    plot_ppc_pava
    plot_ppc_pava_residuals

--- a/docs/source/gallery/predictive_checks/12_plot_ppc_dist_pit.py
+++ b/docs/source/gallery/predictive_checks/12_plot_ppc_dist_pit.py
@@ -1,0 +1,26 @@
+"""
+# Predictive check with ECDF and PIT Δ-ECDFs.
+
+Plot of the ECDF (right) of the PIT values (left) for samples from the posterior predictive and observed data.
+
+---
+
+:::{seealso}
+API Documentation: {func}`~arviz_plots.plot_ppc_pit`
+
+EABM chapter on [Posterior predictive checks with PIT-ECDFs](https://arviz-devs.github.io/EABM/Chapters/Prior_posterior_predictive_checks.html#pit-ecdfs)
+:::
+"""
+from arviz_base import load_arviz_data
+
+import arviz_plots as azp
+
+azp.style.use("arviz-variat")
+
+dt = load_arviz_data("rugby")
+pc = azp.plot_ppc_dist_pit(
+    dt,
+    kind="ecdf",
+    backend="none",
+)
+pc.show()

--- a/src/arviz_plots/backend/__init__.py
+++ b/src/arviz_plots/backend/__init__.py
@@ -8,4 +8,5 @@ Each submodule inside ``arviz_plots.backend`` is expected to implement the same 
 with the same call signature. Thus, adding a new backend requires only
 implementing this common interface for it, with no changes to any of the other modules.
 """
+
 from arviz_plots.backend.none import *

--- a/src/arviz_plots/backend/alias_utils.py
+++ b/src/arviz_plots/backend/alias_utils.py
@@ -1,4 +1,5 @@
 """Backend agnostic utilities for handling arguments and aliases."""
+
 import re
 
 

--- a/src/arviz_plots/backend/bokeh/__init__.py
+++ b/src/arviz_plots/backend/bokeh/__init__.py
@@ -1,4 +1,5 @@
 """Bokeh interface layer."""
+
 from .core import (
     ciliney,
     create_plotting_grid,

--- a/src/arviz_plots/backend/bokeh/core.py
+++ b/src/arviz_plots/backend/bokeh/core.py
@@ -1,4 +1,5 @@
 """Bokeh interface layer."""
+
 # pylint: disable=protected-access
 
 import math

--- a/src/arviz_plots/backend/bokeh/legend.py
+++ b/src/arviz_plots/backend/bokeh/legend.py
@@ -1,4 +1,5 @@
 """Bokeh manual legend generation."""
+
 import warnings
 
 from bokeh.models import Legend

--- a/src/arviz_plots/backend/matplotlib/__init__.py
+++ b/src/arviz_plots/backend/matplotlib/__init__.py
@@ -1,4 +1,5 @@
 """Matplotlib interface layer."""
+
 from .core import (
     ciliney,
     create_plotting_grid,

--- a/src/arviz_plots/backend/matplotlib/legend.py
+++ b/src/arviz_plots/backend/matplotlib/legend.py
@@ -1,4 +1,5 @@
 """Matplotlib manual legend generation."""
+
 from matplotlib.lines import Line2D
 
 from .core import expand_aesthetic_aliases

--- a/src/arviz_plots/backend/none/__init__.py
+++ b/src/arviz_plots/backend/none/__init__.py
@@ -1,4 +1,5 @@
 """None plotting backend."""
+
 from .core import (
     ciliney,
     create_plotting_grid,

--- a/src/arviz_plots/backend/plotly/__init__.py
+++ b/src/arviz_plots/backend/plotly/__init__.py
@@ -1,4 +1,5 @@
 """Plotly interface layer."""
+
 from .core import (
     ciliney,
     create_plotting_grid,

--- a/src/arviz_plots/backend/plotly/legend.py
+++ b/src/arviz_plots/backend/plotly/legend.py
@@ -1,4 +1,5 @@
 """Plotly legend generation."""
+
 from functools import partial
 
 import numpy as np

--- a/src/arviz_plots/backend/plotly/templates.py
+++ b/src/arviz_plots/backend/plotly/templates.py
@@ -1,4 +1,5 @@
 """Plotly templates for ArviZ styles."""
+
 import plotly.graph_objects as go
 
 axis_common = {"showgrid": False, "ticks": "outside", "showline": True, "zeroline": False}

--- a/src/arviz_plots/plots/__init__.py
+++ b/src/arviz_plots/plots/__init__.py
@@ -24,6 +24,7 @@ from .parallel_plot import plot_parallel
 from .pava_calibration_plot import plot_ppc_pava
 from .pava_residual_plot import plot_ppc_pava_residuals
 from .ppc_censored_plot import plot_ppc_censored
+from .ppc_dist_pit_plot import plot_ppc_dist_pit
 from .ppc_dist_plot import plot_ppc_dist
 from .ppc_interval_plot import plot_ppc_interval
 from .ppc_pit_plot import plot_ppc_pit
@@ -64,6 +65,7 @@ __all__ = [
     "plot_parallel",
     "plot_ppc_censored",
     "plot_ppc_dist",
+    "plot_ppc_dist_pit",
     "plot_ppc_interval",
     "plot_ppc_rootogram",
     "plot_prior_posterior",

--- a/src/arviz_plots/plots/combine.py
+++ b/src/arviz_plots/plots/combine.py
@@ -1,4 +1,5 @@
 """Elements to combine multiple batteries-included plots into a single figure."""
+
 from importlib import import_module
 
 from arviz_base import rcParams

--- a/src/arviz_plots/plots/compare_plot.py
+++ b/src/arviz_plots/plots/compare_plot.py
@@ -1,4 +1,5 @@
 """Compare plot code."""
+
 from collections.abc import Mapping
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/convergence_dist_plot.py
+++ b/src/arviz_plots/plots/convergence_dist_plot.py
@@ -1,4 +1,5 @@
 """Convergence diagnostic distribution plot code."""
+
 import warnings
 from collections.abc import Mapping, Sequence
 from importlib import import_module

--- a/src/arviz_plots/plots/dgof_dist_plot.py
+++ b/src/arviz_plots/plots/dgof_dist_plot.py
@@ -1,4 +1,5 @@
 """dgof_dist plot code."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/ecdf_plot.py
+++ b/src/arviz_plots/plots/ecdf_plot.py
@@ -1,4 +1,5 @@
 """Plot PIT Δ-ECDF."""
+
 import warnings
 from collections.abc import Mapping, Sequence
 from importlib import import_module
@@ -259,10 +260,9 @@ def plot_ecdf_pit(
         upper_ci = upper_ci - x_ci
 
     else:
-        p_values, shapley_vals = distribution.azstats.uniformity_test(
+        p_values, shapley_vals, _ = distribution.azstats.uniformity_test(
             dim=sample_dims, method=method
         )
-
         gamma = stats.get("ecdf_pit", {}).get("gamma", 0)
         highlight = (shapley_vals > gamma) & (p_values < alpha)
         suspicious_mask = highlight.rename({"pit_dim": "ecdf_dim"})

--- a/src/arviz_plots/plots/energy_plot.py
+++ b/src/arviz_plots/plots/energy_plot.py
@@ -1,4 +1,5 @@
 """Energy plot code."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/forest_plot.py
+++ b/src/arviz_plots/plots/forest_plot.py
@@ -1,4 +1,5 @@
 """Forest plot code."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/loo_interval_plot.py
+++ b/src/arviz_plots/plots/loo_interval_plot.py
@@ -1,4 +1,5 @@
 """Predictive intervals plot."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/loo_pit_plot.py
+++ b/src/arviz_plots/plots/loo_pit_plot.py
@@ -1,4 +1,5 @@
 """Plot loo pit."""
+
 import warnings
 from collections.abc import Mapping, Sequence
 from typing import Any, Literal

--- a/src/arviz_plots/plots/pair_focus_plot.py
+++ b/src/arviz_plots/plots/pair_focus_plot.py
@@ -1,4 +1,5 @@
 """Pair focus plot code."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/pair_plot.py
+++ b/src/arviz_plots/plots/pair_plot.py
@@ -1,4 +1,5 @@
 """Pair plot code."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/parallel_plot.py
+++ b/src/arviz_plots/plots/parallel_plot.py
@@ -1,4 +1,5 @@
 """Pair focus plot code."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/pava_calibration_plot.py
+++ b/src/arviz_plots/plots/pava_calibration_plot.py
@@ -1,4 +1,5 @@
 """Posterior predictive check using PAV-adjusted calibration plot."""
+
 import warnings
 from collections.abc import Mapping, Sequence
 from importlib import import_module

--- a/src/arviz_plots/plots/pava_residual_plot.py
+++ b/src/arviz_plots/plots/pava_residual_plot.py
@@ -1,4 +1,5 @@
 """Posterior predictive check for residuals using PAV-adjusted calibration."""
+
 import warnings
 from collections.abc import Mapping, Sequence
 from importlib import import_module

--- a/src/arviz_plots/plots/ppc_dist_pit_plot.py
+++ b/src/arviz_plots/plots/ppc_dist_pit_plot.py
@@ -1,0 +1,330 @@
+"""Predictive check using densities and PIT Δ-ECDFs."""
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+import xarray as xr
+from arviz_base.labels import BaseLabeller
+from arviz_base.validate import validate_dict_argument, validate_or_use_rcparam
+
+from arviz_plots.plot_collection import PlotCollection
+from arviz_plots.plots.dist_plot import plot_dist
+from arviz_plots.plots.ecdf_plot import plot_ecdf_pit
+from arviz_plots.plots.utils import filter_aes, get_visual_kwargs, set_grid_layout
+from arviz_plots.plots.utils_ppc import get_ppc_pit, get_suspicious_mask_ds, prepare_ppc_dist_data
+from arviz_plots.visuals import trace_rug
+
+
+def plot_ppc_dist_pit(
+    dt,
+    *,
+    var_names=None,
+    filter_vars=None,
+    group="posterior_predictive",
+    coords=None,
+    sample_dims=None,
+    kind=None,
+    num_samples=50,
+    method="pot_c",
+    envelope_prob=None,
+    coverage=False,
+    plot_collection=None,
+    backend=None,
+    labeller=None,
+    aes_by_visuals: Mapping[
+        Literal[
+            "predictive_dist",
+            "observed_dist",
+            "ecdf_lines",
+            "credible_interval",
+            "suspicious_points",
+            "p_value_text",
+            "title",
+        ],
+        Sequence[str],
+    ] = None,
+    visuals: Mapping[
+        Literal[
+            "predictive_dist",
+            "observed_dist",
+            "ecdf_lines",
+            "credible_interval",
+            "suspicious_points",
+            "p_value_text",
+            "xlabel_dist",
+            "xlabel_pit",
+            "ylabel",
+            "title",
+            "remove_axis",
+        ],
+        Mapping[str, Any] | bool,
+    ] = None,
+    stats: Mapping[
+        Literal["predictive_dist", "observed_dist", "ecdf_pit"], Mapping[str, Any] | xr.Dataset
+    ] = None,
+    **pc_kwargs,
+):
+    """1D marginals for the predictive distribution and PIT Δ-ECDF.
+
+    The left column shows 1D marginals for the posterior predictive distribution
+    overlaid on the observed data, identical to :func:`~arviz_plots.plot_ppc_dist`.
+
+    The right column shows the empirical CDF (ECDF) of the PIT values minus the expected
+    CDF, identical to :func:`~arviz_plots.plot_ppc_pit`.
+
+    Suspicious observations are computed from the uniformity test and they are highlighted
+    in both columns, either as rug marks at y=0 in the dist column or as points in ECDF for
+    the PIT column. The suspicious observations are the ones that contribute the most to
+    deviations from uniformity.
+
+    Parameters
+    ----------
+    dt : DataTree
+        Input data with ``posterior_predictive`` and ``observed_data`` groups.
+    var_names : str or list of str, optional
+        Variables to plot.
+    filter_vars : {None, "like", "regex"}, optional
+    group : str,
+        Group to be plotted. Defaults to "posterior_predictive".
+        It could also be "prior_predictive".
+    coords : dict, optional
+    sample_dims : str or sequence of hashable, optional
+        Defaults to ``rcParams["data.sample_dims"]``.
+    kind : {"auto", "kde", "hist", "ecdf", "dot"}, optional
+        Density kind for the dist column.
+        Defaults to ``rcParams["plot.density_kind"]``.
+    num_samples : int, default 50
+        Number of predictive draws to overlay in the dist column.
+    method : {"pot_c", "prit_c", "piet_c", "envelope"}, default "pot_c"
+        Uniformity-test method for the PIT column.
+    envelope_prob : float, optional
+        Probability inside the simultaneous envelope.
+        Defaults to ``rcParams["stats.envelope_prob"]``.
+    coverage : bool, default False
+        If True, replace PIT with ``2|PIT - 0.5|`` to assess ETI coverage.
+    plot_collection : PlotCollection, optional
+    backend : {"matplotlib", "bokeh", "plotly"}, optional
+    labeller : labeller, optional
+    aes_by_visuals : mapping, optional
+        Valid keys: ``predictive_dist``, ``observed_dist``, ``ecdf_lines``,
+        ``credible_interval``, ``suspicious_points``, ``p_value_text``, ``title``.
+    visuals : mapping, optional
+        Valid keys:
+
+        * predictive_dist  -> density lines for predictive draws
+        * observed_dist    -> density line for observed data
+        * ecdf_lines       -> passed to :func:`~arviz_plots.visuals.ecdf_line`
+        * credible_interval -> only when ``method="envelope"``
+        * suspicious_points -> passed to :func:`~arviz_plots.visuals.scatter_xy`
+        * p_value_text     -> passed to :func:`~arviz_plots.visuals.annotate_xy`
+        * xlabel_dist      -> x-axis label for the dist column
+        * xlabel_pit       -> x-axis label for the PIT column
+        * ylabel           -> y-axis label for the PIT column
+        * title            -> passed to :func:`~arviz_plots.visuals.labelled_title`
+        * remove_axis      -> set to ``False`` to skip axis removal
+
+    stats : mapping, optional
+        Valid keys: ``predictive_dist``, ``observed_dist``, ``ecdf_pit``.
+
+    **pc_kwargs
+        Passed to :class:`~arviz_plots.PlotCollection.grid`.
+
+    Returns
+    -------
+    PlotCollection
+
+    See Also
+    --------
+    plot_ppc_dist : Predictive density check only.
+    plot_ppc_pit  : PIT Δ-ECDF check only.
+
+    Examples
+    --------
+    .. plot::
+        :context: close-figs
+
+        >>> from arviz_plots import plot_ppc_dist_pit, style
+        >>> style.use("arviz-variat")
+        >>> from arviz_base import load_arviz_data
+        >>> dt = load_arviz_data('radon')
+        >>> plot_ppc_dist_pit(dt)
+
+    .. minigallery:: plot_ppc_dist_pit
+    """
+    envelope_prob = validate_or_use_rcparam(envelope_prob, "stats.envelope_prob")
+    aes_by_visuals = validate_dict_argument(aes_by_visuals, (plot_ppc_dist_pit, "aes_by_visuals"))
+    visuals = validate_dict_argument(visuals, (plot_ppc_dist_pit, "visuals"))
+    stats = validate_dict_argument(stats, (plot_ppc_dist_pit, "stats"))
+    gamma = stats.get("ecdf_pit", {}).get("gamma", 0)
+    alpha = 1 - envelope_prob
+
+    if method not in {"envelope", "pot_c", "prit_c", "piet_c"}:
+        raise ValueError(
+            f"Method {method!r} not supported. "
+            "Choose from 'envelope', 'pot_c', 'prit_c' or 'piet_c'."
+        )
+
+    plot_bknd, pp_dims, sample_dims, predictive_dist, predictive_dist_sub, observed_dist = (
+        prepare_ppc_dist_data(
+            dt,
+            var_names=var_names,
+            filter_vars=filter_vars,
+            group=group,
+            coords=coords,
+            sample_dims=sample_dims,
+            kind=kind,
+            num_samples=num_samples,
+            plot_collection=plot_collection,
+            backend=backend,
+            stats=stats,
+            require_observed=True,
+        )
+    )
+
+    pit_dt = get_ppc_pit(predictive_dist, observed_dist, sample_dims, coverage, method)
+    pit_dims = pit_dt.ecdf_pit.dims
+
+    if plot_collection is None:
+        pc_kwargs["figure_kwargs"] = pc_kwargs.get("figure_kwargs", {}).copy()
+        pc_kwargs["figure_kwargs"].setdefault("sharex", False)
+        pc_kwargs["figure_kwargs"].setdefault("sharey", False)
+
+        pc_kwargs["aes"] = pc_kwargs.get("aes", {}).copy()
+        pc_kwargs["aes"].setdefault("overlay_ppc", ["sample"])
+        pc_kwargs.setdefault("cols", ["column"])
+        pc_kwargs.setdefault("rows", "__variable__")
+
+        pc_kwargs = set_grid_layout(pc_kwargs, plot_bknd, predictive_dist_sub, num_cols=2)
+
+        plot_collection = PlotCollection.grid(
+            predictive_dist_sub.expand_dims(column=2).assign_coords(column=["dist", "pit"]),
+            backend=backend,
+            **pc_kwargs,
+        )
+
+    if labeller is None:
+        labeller = BaseLabeller()
+
+    # predictive density
+    pred_density_kwargs = get_visual_kwargs(visuals, "predictive_dist")
+    if pred_density_kwargs is not False:
+        pred_density_kwargs.setdefault("alpha", 0.3)
+        pred_visuals = {
+            "dist": pred_density_kwargs,
+            "credible_interval": False,
+            "point_estimate": False,
+            "point_estimate_text": False,
+            "title": visuals.get("title", {}),
+            "rug": False,
+            "remove_axis": visuals.get("remove_axis", {}),
+        }
+        pred_aes_by_visuals = {
+            k.replace("predictive_", ""): v
+            for k, v in aes_by_visuals.items()
+            if k != "observed_dist"
+        }
+        plot_collection.coords = {"column": "dist"}
+        plot_collection = plot_dist(
+            predictive_dist_sub,
+            group=group,
+            sample_dims=pp_dims,
+            kind=kind,
+            visuals=pred_visuals,
+            aes_by_visuals=pred_aes_by_visuals,
+            pc_kwargs=pc_kwargs,
+            plot_collection=plot_collection,
+            stats={"dist": stats.get("predictive_dist", {})},
+        )
+        plot_collection.coords = None
+        plot_collection.rename_visuals(dist="predictive_dist")
+
+    # observed density
+    observed_density_kwargs = get_visual_kwargs(
+        visuals, "observed_dist", False if group == "prior_predictive" else None
+    )
+    if observed_density_kwargs is not False:
+        observed_density_kwargs.setdefault("color", "B1")
+        observed_visuals = {
+            "dist": observed_density_kwargs,
+            "credible_interval": False,
+            "point_estimate": False,
+            "point_estimate_text": False,
+            "title": False,
+            "rug": False,
+            "remove_axis": False,
+        }
+        obs_aes_by_visuals = (
+            {"dist": aes_by_visuals["observed_dist"]} if "observed_dist" in aes_by_visuals else {}
+        )
+        plot_collection.coords = {"column": "dist"}
+        plot_collection = plot_dist(
+            observed_dist,
+            group="observed_data",
+            sample_dims=pp_dims,
+            kind=kind,
+            visuals=observed_visuals,
+            aes_by_visuals=obs_aes_by_visuals,
+            plot_collection=plot_collection,
+            stats={"dist": stats.get("observed_dist", {})},
+        )
+        plot_collection.coords = None
+        plot_collection.rename_visuals(dist="observed_dist")
+
+    # Plot suspicious obs from uniformity test
+    rug_kwargs = get_visual_kwargs(visuals, "suspicious_points")
+    if rug_kwargs is not False and method != "envelope":
+        suspicious_mask_ds = get_suspicious_mask_ds(observed_dist, pit_dt, alpha, gamma, method)
+        rug_kwargs.setdefault("color", "C1")
+        rug_kwargs.setdefault("marker", "|")
+        _, _, rug_ignore = filter_aes(
+            plot_collection, aes_by_visuals, "suspicious_points", sample_dims
+        )
+        plot_collection.map(
+            trace_rug,
+            "suspicious_points",
+            data=observed_dist,
+            mask=suspicious_mask_ds,
+            ignore_aes=rug_ignore,
+            xname=False,
+            y=0,
+            coords={"column": "dist"},
+            **rug_kwargs,
+        )
+
+    pit_visuals = {
+        "ylabel": visuals.get("ylabel", {}),
+        "remove_axis": False,
+        "xlabel": visuals.get("xlabel_pit", {"text": "ETI %" if coverage else "PIT"}),
+        "title": visuals.get("title", {}),
+    }
+    for key in ("ecdf_lines", "credible_interval", "suspicious_points", "p_value_text"):
+        if key in visuals:
+            pit_visuals[key] = visuals[key]
+
+    pit_aes_by_visuals = {
+        k: v
+        for k, v in aes_by_visuals.items()
+        if k in ("ecdf_lines", "credible_interval", "suspicious_points", "p_value_text")
+    }
+
+    plot_collection.coords = {"column": "pit"}
+    plot_collection = plot_ecdf_pit(
+        pit_dt,
+        var_names=var_names,
+        filter_vars=filter_vars,
+        group="ecdf_pit",
+        coords=coords,
+        sample_dims=pit_dims,
+        method=method,
+        envelope_prob=envelope_prob,
+        coverage=coverage,
+        plot_collection=plot_collection,
+        backend=backend,
+        labeller=labeller,
+        aes_by_visuals=pit_aes_by_visuals,
+        visuals=pit_visuals,
+        stats={"ecdf_pit": stats.get("ecdf_pit", {})},
+    )
+    plot_collection.coords = None
+
+    return plot_collection

--- a/src/arviz_plots/plots/ppc_dist_plot.py
+++ b/src/arviz_plots/plots/ppc_dist_plot.py
@@ -1,28 +1,16 @@
 """Predictive check using densities."""
 
-import warnings
 from collections.abc import Mapping, Sequence
-from importlib import import_module
 from typing import Any, Literal
 
-import numpy as np
 import xarray as xr
-from arviz_base import rcParams
 from arviz_base.labels import BaseLabeller
-from arviz_base.validate import (
-    validate_dict_argument,
-    validate_or_use_rcparam,
-    validate_sample_dims,
-)
+from arviz_base.validate import validate_dict_argument
 
 from arviz_plots.plot_collection import PlotCollection
 from arviz_plots.plots.dist_plot import plot_dist
-from arviz_plots.plots.utils import (
-    get_visual_kwargs,
-    process_group_variables_coords,
-    set_wrap_layout,
-)
-from arviz_plots.plots.utils_plot_types import warn_if_binary, warn_if_discrete
+from arviz_plots.plots.utils import get_visual_kwargs, set_wrap_layout
+from arviz_plots.plots.utils_ppc import prepare_ppc_dist_data
 
 
 def plot_ppc_dist(
@@ -174,53 +162,23 @@ def plot_ppc_dist(
 
     .. minigallery:: plot_ppc_dist
     """
-    kind = validate_or_use_rcparam(kind, "plot.density_kind")
     stats = validate_dict_argument(stats, (plot_ppc_dist, "stats"))
     visuals = validate_dict_argument(visuals, (plot_ppc_dist, "visuals"))
 
-    if backend is None:
-        if plot_collection is None:
-            backend = rcParams["plot.backend"]
-        else:
-            backend = plot_collection.backend
-
-    plot_bknd = import_module(f".backend.{backend}", package="arviz_plots")
-
-    rng = np.random.default_rng(4214)
-
-    predictive_dist = process_group_variables_coords(
-        dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords
+    plot_bknd, pp_dims, sample_dims, _, predictive_dist, observed_dist = prepare_ppc_dist_data(
+        dt,
+        var_names=var_names,
+        filter_vars=filter_vars,
+        group=group,
+        coords=coords,
+        sample_dims=sample_dims,
+        kind=kind,
+        num_samples=num_samples,
+        plot_collection=plot_collection,
+        backend=backend,
+        stats=stats,
+        warn_discrete_dist=True,
     )
-    sample_dims = validate_sample_dims(sample_dims, data=predictive_dist)
-    pp_dims = [dim for dim in predictive_dist.dims if dim not in sample_dims]
-
-    if "observed_data" in dt:
-        observed_dist = process_group_variables_coords(
-            dt,
-            group="observed_data",
-            var_names=var_names,
-            filter_vars=filter_vars,
-            coords=coords,
-        )
-    else:
-        observed_dist = None
-
-    warn_if_binary(observed_dist, predictive_dist)
-    warn_if_discrete(observed_dist, predictive_dist, kind)
-
-    # Select a random subset of samples
-    n_pp_samples = np.prod(
-        [predictive_dist.sizes[dim] for dim in sample_dims if dim in predictive_dist.dims]
-    )
-    if num_samples > n_pp_samples:
-        num_samples = n_pp_samples
-        warnings.warn("num_samples is larger than the number of predictive samples.")
-
-    if kind == "dot":
-        stats.setdefault("predictive_dist", {"top_only": True})
-
-    pp_sample_ix = rng.choice(n_pp_samples, size=num_samples, replace=False)
-    predictive_dist = predictive_dist.stack(sample=sample_dims).isel(sample=pp_sample_ix)
 
     if plot_collection is None:
         pc_kwargs["figure_kwargs"] = pc_kwargs.get("figure_kwargs", {}).copy()
@@ -272,7 +230,8 @@ def plot_ppc_dist(
             plot_collection=plot_collection,
             stats={"dist": stats.get("predictive_dist", {})},
         )
-        plot_collection.rename_visuals(dist="predictive_dist")
+        if plot_collection.coords is None:
+            plot_collection.rename_visuals(dist="predictive_dist")
 
     # Plot the observed density
     observed_density_kwargs = get_visual_kwargs(
@@ -303,6 +262,7 @@ def plot_ppc_dist(
             plot_collection=plot_collection,
             stats={"dist": stats.get("observed_dist", {})},
         )
-        plot_collection.rename_visuals(dist="observed_dist")
+        if plot_collection.coords is None:
+            plot_collection.rename_visuals(dist="observed_dist")
 
     return plot_collection

--- a/src/arviz_plots/plots/ppc_interval_plot.py
+++ b/src/arviz_plots/plots/ppc_interval_plot.py
@@ -1,4 +1,5 @@
 """Predictive intervals plot."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/ppc_pit_plot.py
+++ b/src/arviz_plots/plots/ppc_pit_plot.py
@@ -1,19 +1,19 @@
 """Plot ppc pit."""
+
 from collections.abc import Mapping, Sequence
 from typing import Any, Literal
 
-import numpy as np
 import xarray as xr
 from arviz_base.validate import (
     validate_dict_argument,
     validate_or_use_rcparam,
     validate_sample_dims,
 )
-from arviz_stats.base.array import array_stats
 
-from arviz_plots.plots import plot_ecdf_pit
+from arviz_plots.plots.ecdf_plot import plot_ecdf_pit
 from arviz_plots.plots.utils import process_group_variables_coords
 from arviz_plots.plots.utils_plot_types import warn_if_binary, warn_if_prior_predictive
+from arviz_plots.plots.utils_ppc import get_ppc_pit
 
 
 def plot_ppc_pit(
@@ -198,9 +198,7 @@ def plot_ppc_pit(
             f"Method {method} not supported. Choose from 'envelope', 'pot_c', 'prit_c' or 'piet_c'."
         )
 
-    pareto_pit = method in ["pot_c", "piet_c"]
-
-    new_dt = _ppc_pit(predictive_dist, observed_dist, sample_dims, coverage, pareto_pit)
+    new_dt = get_ppc_pit(predictive_dist, observed_dist, sample_dims, coverage, method)
 
     visuals.setdefault("ylabel", {})
     visuals.setdefault("remove_axis", False)
@@ -226,52 +224,3 @@ def plot_ppc_pit(
     )
 
     return plot_collection
-
-
-def _ppc_pit(predictive_dist, observed_dist, sample_dims, coverage, pareto_pit):
-    """Compute Pareto-smoothed PIT ECDF values.
-
-    The probability of the posterior predictive being less than or equal to the observed data
-    should be uniformly distributed. This function computes the PIT values with
-    Generalized Pareto Distribution tail refinement.
-
-    Parameters
-    ----------
-    predictive_dist : xarray.Dataset
-        The posterior predictive distribution.
-    observed_dist : xarray.Dataset
-        The observed data.
-    sample_dims : str or sequence of hashable, optional
-        Dimensions to reduce.
-    coverage : bool
-        Whether to compute the coverage.
-    pareto_pit : bool
-        Whether to use Pareto-smoothed PIT values.
-    """
-    rng = np.random.default_rng(214)
-
-    dictio = {}
-    for var in observed_dist.data_vars:
-        if pareto_pit:
-            pred_stacked = predictive_dist[var].stack(__sample__=sample_dims)
-            vals = xr.apply_ufunc(
-                array_stats._pareto_pit_vec,  # pylint: disable=protected-access
-                pred_stacked,
-                observed_dist[var],
-                input_core_dims=[["__sample__"], []],
-                output_core_dims=[[]],
-                vectorize=False,
-                kwargs={"rng": rng},
-            )
-        else:
-            vals_less = (predictive_dist[var] < observed_dist[var]).mean(sample_dims)
-            vals_eq = (predictive_dist[var] == observed_dist[var]).mean(sample_dims)
-            urvs = rng.uniform(size=vals_less.values.shape)
-            vals = vals_less + urvs * vals_eq
-
-        if coverage:
-            vals = 2 * np.abs(vals - 0.5)
-
-        dictio[var] = vals
-
-    return xr.DataTree.from_dict({"ecdf_pit": xr.Dataset(dictio)})

--- a/src/arviz_plots/plots/ppc_rootogram_plot.py
+++ b/src/arviz_plots/plots/ppc_rootogram_plot.py
@@ -1,4 +1,5 @@
 """Plot ppc rootogram for discrete (count) data."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/ppc_tstat.py
+++ b/src/arviz_plots/plots/ppc_tstat.py
@@ -1,4 +1,5 @@
 """ppc t-stat plot code."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/psense_dist_plot.py
+++ b/src/arviz_plots/plots/psense_dist_plot.py
@@ -1,4 +1,5 @@
 """PsenseDist plot code."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/psense_quantities_plot.py
+++ b/src/arviz_plots/plots/psense_quantities_plot.py
@@ -1,4 +1,5 @@
 """psense quantities plot code."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/rank_plot.py
+++ b/src/arviz_plots/plots/rank_plot.py
@@ -1,4 +1,5 @@
 """Plot fractional rank."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/ridge_plot.py
+++ b/src/arviz_plots/plots/ridge_plot.py
@@ -1,4 +1,5 @@
 """Ridge plot code."""
+
 import warnings
 from collections.abc import Mapping, Sequence
 from importlib import import_module

--- a/src/arviz_plots/plots/trace_dist_plot.py
+++ b/src/arviz_plots/plots/trace_dist_plot.py
@@ -1,4 +1,5 @@
 """TraceDist plot code."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/trace_plot.py
+++ b/src/arviz_plots/plots/trace_plot.py
@@ -1,4 +1,5 @@
 """Trace plot code."""
+
 from collections.abc import Mapping, Sequence
 from importlib import import_module
 from typing import Any, Literal

--- a/src/arviz_plots/plots/utils.py
+++ b/src/arviz_plots/plots/utils.py
@@ -1,4 +1,5 @@
 """Utilities for batteries included plots."""
+
 import warnings
 from copy import copy
 from importlib import import_module

--- a/src/arviz_plots/plots/utils_plot_types.py
+++ b/src/arviz_plots/plots/utils_plot_types.py
@@ -1,4 +1,5 @@
 """Utility functions to check data types for plotting functions."""
+
 import warnings
 
 import numpy as np

--- a/src/arviz_plots/plots/utils_ppc.py
+++ b/src/arviz_plots/plots/utils_ppc.py
@@ -1,0 +1,149 @@
+"""Utility functions for PPC distribution and PIT plots."""
+
+import warnings
+from importlib import import_module
+
+import numpy as np
+import xarray as xr
+from arviz_base import rcParams
+from arviz_base.validate import validate_or_use_rcparam, validate_sample_dims
+from arviz_stats.base import array_stats
+
+from arviz_plots.plots.utils import process_group_variables_coords
+from arviz_plots.plots.utils_plot_types import (
+    warn_if_binary,
+    warn_if_discrete,
+    warn_if_prior_predictive,
+)
+
+
+def prepare_ppc_dist_data(
+    dt,
+    *,
+    var_names,
+    filter_vars,
+    group,
+    coords,
+    sample_dims,
+    kind,
+    num_samples,
+    plot_collection,
+    backend,
+    stats,
+    require_observed=False,
+    warn_discrete_dist=False,
+):
+    """Prepare data for PPC distribution and PIT plots."""
+    kind = validate_or_use_rcparam(kind, "plot.density_kind")
+
+    if backend is None:
+        if plot_collection is None:
+            backend = rcParams["plot.backend"]
+        else:
+            backend = plot_collection.backend
+
+    plot_bknd = import_module(f".backend.{backend}", package="arviz_plots")
+
+    predictive_dist = process_group_variables_coords(
+        dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords
+    )
+    sample_dims = validate_sample_dims(sample_dims, data=predictive_dist)
+    pp_dims = [dim for dim in predictive_dist.dims if dim not in sample_dims]
+
+    if require_observed or "observed_data" in dt:
+        observed_dist = process_group_variables_coords(
+            dt,
+            group="observed_data",
+            var_names=var_names,
+            filter_vars=filter_vars,
+            coords=coords,
+        )
+    else:
+        observed_dist = None
+
+    warn_if_binary(observed_dist, predictive_dist)
+    if warn_discrete_dist:
+        warn_if_discrete(observed_dist, predictive_dist, kind)
+
+    warn_if_prior_predictive(group)
+
+    n_pp_samples = int(
+        np.prod([predictive_dist.sizes[dim] for dim in sample_dims if dim in predictive_dist.dims])
+    )
+    if num_samples > n_pp_samples:
+        num_samples = n_pp_samples
+        warnings.warn("num_samples is larger than the number of predictive samples.")
+
+    if kind == "dot" and stats is not None:
+        stats.setdefault("predictive_dist", {"top_only": True})
+
+    rng = np.random.default_rng(4214)
+    pp_sample_ix = rng.choice(n_pp_samples, size=num_samples, replace=False)
+    predictive_dist_sub = predictive_dist.stack(sample=sample_dims).isel(sample=pp_sample_ix)
+
+    return plot_bknd, pp_dims, sample_dims, predictive_dist, predictive_dist_sub, observed_dist
+
+
+def get_suspicious_mask_ds(observed_dist, pit_dt, alpha, gamma, method):
+    """Compute most suspicious observations based on PIT uniformity test results."""
+    pit_ds = pit_dt["ecdf_pit"].ds[list(observed_dist.data_vars)]
+    p_values, _, shapley_vals = pit_ds.azstats.uniformity_test(dim=pit_ds.dims, method=method)
+
+    highlight = (shapley_vals > gamma) & (p_values < alpha)
+    return xr.Dataset(
+        {
+            var: highlight[var].rename({"pit_dim": next(iter(pit_ds[var].dims))})
+            for var in highlight.data_vars
+        }
+    )
+
+
+def get_ppc_pit(predictive_dist, observed_dist, sample_dims, coverage, method):
+    """Compute PIT ECDF values, with optional coverage transformation and Pareto tail refinement.
+
+    The probability of the posterior predictive being less than or equal to the observed data
+    should be uniformly distributed. This function computes the PIT values with
+    Generalized Pareto Distribution tail refinement.
+
+    Parameters
+    ----------
+    predictive_dist : xarray.Dataset
+        The posterior predictive distribution.
+    observed_dist : xarray.Dataset
+        The observed data.
+    sample_dims : str or sequence of hashable, optional
+        Dimensions to reduce.
+    coverage : bool
+        Whether to compute the coverage.
+    method : {"envelope", "pot_c", "prit_c", "piet_c"}
+        The method to use for PIT computation.
+    """
+    rng = np.random.default_rng(214)
+
+    pareto_pit = method in ("pot_c", "piet_c")
+
+    dictio = {}
+    for var in observed_dist.data_vars:
+        if pareto_pit:
+            pred_stacked = predictive_dist[var].stack(__sample__=sample_dims)
+            vals = xr.apply_ufunc(
+                array_stats._pareto_pit_vec,  # pylint: disable=protected-access
+                pred_stacked,
+                observed_dist[var],
+                input_core_dims=[["__sample__"], []],
+                output_core_dims=[[]],
+                vectorize=False,
+                kwargs={"rng": rng},
+            )
+        else:
+            vals_less = (predictive_dist[var] < observed_dist[var]).mean(sample_dims)
+            vals_eq = (predictive_dist[var] == observed_dist[var]).mean(sample_dims)
+            urvs = rng.uniform(size=vals_less.values.shape)
+            vals = vals_less + urvs * vals_eq
+
+        if coverage:
+            vals = 2 * np.abs(vals - 0.5)
+
+        dictio[var] = vals
+
+    return xr.DataTree.from_dict({"ecdf_pit": xr.Dataset(dictio)})

--- a/src/arviz_plots/style.py
+++ b/src/arviz_plots/style.py
@@ -1,4 +1,5 @@
 """Style/templating helpers."""
+
 from pathlib import Path
 
 from arviz_base import rcParams

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,4 +1,5 @@
 """Test fixtures."""
+
 from importlib import import_module
 
 import pytest

--- a/tests/test_hypothesis_plots.py
+++ b/tests/test_hypothesis_plots.py
@@ -30,6 +30,7 @@ from arviz_plots import (
     plot_parallel,
     plot_ppc_censored,
     plot_ppc_dist,
+    plot_ppc_dist_pit,
     plot_ppc_interval,
     plot_ppc_pava,
     plot_ppc_pava_residuals,
@@ -899,6 +900,39 @@ def test_plot_parallel(datatree, visuals, norm_method):
 )
 def test_plot_ppc_dist(datatree, kind, visuals):
     pc = plot_ppc_dist(
+        datatree,
+        backend="none",
+        kind=kind,
+        visuals=visuals,
+    )
+    assert "plot" in pc.viz.children
+    for visual, value in visuals.items():
+        if value is False:
+            assert visual not in pc.viz.children
+        else:
+            assert visual in pc.viz.children
+            assert all(
+                var_name in pc.viz[visual].data_vars
+                for var_name in datatree["posterior_predictive"].data_vars
+            )
+
+
+@pytest.mark.filterwarnings("ignore:nquantiles .* must be .*number of data points.*;using")
+@given(
+    visuals=st.fixed_dictionaries(
+        {},
+        optional={
+            "predictive_dist": visuals_value_no_false,
+            "observed_dist": visuals_value,
+            "suspicious_points": visuals_value,
+            "title": visuals_value,
+            "remove_axis": st.just(False),
+        },
+    ),
+    kind=kind_value,
+)
+def test_plot_ppc_dist_pit(datatree, kind, visuals):
+    pc = plot_ppc_dist_pit(
         datatree,
         backend="none",
         kind=kind,

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -29,6 +29,7 @@ from arviz_plots import (
     plot_parallel,
     plot_ppc_censored,
     plot_ppc_dist,
+    plot_ppc_dist_pit,
     plot_ppc_interval,
     plot_ppc_pava,
     plot_ppc_pava_residuals,
@@ -695,6 +696,15 @@ class TestPlots:  # pylint: disable=too-many-public-methods
     @pytest.mark.parametrize("kind", ["kde", "ecdf", "hist", "dot"])
     def test_plot_ppc_dist(self, datatree, kind, backend):
         pc = plot_ppc_dist(datatree, kind=kind, backend=backend)
+        assert "figure" in pc.viz.data_vars
+        assert "/overlay_ppc" in pc.aes.groups
+        assert "y" in pc.viz["predictive_dist"]
+        assert "y" in pc.viz["observed_dist"]
+
+    @pytest.mark.filterwarnings("ignore:nquantiles .* must be .*number of data points.*;using")
+    @pytest.mark.parametrize("kind", ["kde", "ecdf", "hist", "dot"])
+    def test_plot_ppc_dist_pit(self, datatree, kind, backend):
+        pc = plot_ppc_dist_pit(datatree, kind=kind, backend=backend)
         assert "figure" in pc.viz.data_vars
         assert "/overlay_ppc" in pc.aes.groups
         assert "y" in pc.viz["predictive_dist"]


### PR DESCRIPTION
Depends on https://github.com/arviz-devs/arviz-stats/pull/358

This adds a new plot that combines `plot_ppc_dist` (left) and `plot_ppc_pit` (right). The highlighted points in the pit plot are also plotted on the left plot as a rug-plot. The exact location of these highlighted points is not always informative (on either side), but having these two plots together side by side with a simple call may still be useful.

<img width="2423" height="559" alt="output" src="https://github.com/user-attachments/assets/6f8fa88a-0050-4857-8ee7-9da836aecb2d" />