### PR TITLE
Add KDE2D to plot_pair

### DIFF
--- a/docs/source/gallery/distribution/08_plot_pair_kde.py
+++ b/docs/source/gallery/distribution/08_plot_pair_kde.py
@@ -1,0 +1,29 @@
+"""
+# 2D KDE for all variables against each other
+
+Plot all variables against each other in the dataset.
+
+---
+
+:::{seealso}
+API Documentation: {func}`~arviz_plots.plot_pair`
+:::
+"""
+from arviz_base import load_arviz_data
+
+import arviz_plots as azp
+
+azp.style.use("arviz-variat")
+
+data = load_arviz_data("centered_eight")
+pc = azp.plot_pair(
+    data,
+    var_names=["mu","theta","tau"],
+    coords= {"school": ["Choate", "Deerfield"]},
+    visuals={"contourf": True,
+             "contour": {"color":"black"},
+             "scatter":False,
+             },
+    backend="none", # change to preferred backend
+)
+pc.show()

--- a/src/arviz_plots/backend/bokeh/__init__.py
+++ b/src/arviz_plots/backend/bokeh/__init__.py
@@ -2,6 +2,8 @@
 
 from .core import (
     ciliney,
+    contour,
+    contourf,
     create_plotting_grid,
     fill_between_y,
     get_background_color,

--- a/src/arviz_plots/backend/bokeh/core.py
+++ b/src/arviz_plots/backend/bokeh/core.py
@@ -935,7 +935,9 @@ def contourf(
     n_bands = len(levels) - 1
 
     if cmap is not None:
-        band_colors = list(getattr(bp, cmap)(n_bands))
+        full_palette = getattr(bp, cmap)(256)
+        positions = [(2 * i + 1) / (2 * n_bands) for i in range(n_bands)]
+        band_colors = [full_palette[round(p * 255)] for p in positions]
     elif color is not unset:
         band_colors = [color] * n_bands
 

--- a/src/arviz_plots/backend/bokeh/core.py
+++ b/src/arviz_plots/backend/bokeh/core.py
@@ -862,3 +862,89 @@ def grid(target, axis, color):
         target.ygrid.grid_line_color = color
     if axis in ["x", "both"]:
         target.xgrid.grid_line_color = color
+
+
+@expand_aesthetic_aliases
+def contour(x, y, density, target, *, levels=None, color=unset, alpha=unset, **artist_kws):
+    """Interface to bokeh for a contour plot.
+
+    Parameters
+    ----------
+    x : array_like of shape (nx,)
+        Grid values along the x axis.
+    y : array_like of shape (ny,)
+        Grid values along the y axis.
+    density : array_like of shape (nx, ny)
+        Density values on the grid.
+    target : bokeh Figure
+        The :term:`plot` to draw on.
+    levels : array_like, optional
+        Density values at which to draw contour lines.
+    color, alpha : any, optional
+        See :ref:`backend_interface_arguments` for details.
+    **artist_kws
+        Passed to :meth:`~bokeh.plotting.figure.multi_line`.
+
+    Returns
+    -------
+    GlyphRenderer
+    """
+    kwargs = {"line_color": color, "line_alpha": alpha}
+    return target.contour(
+        x=np.asarray(x),
+        y=np.asarray(y),
+        z=np.asarray(density).T,
+        levels=levels,
+        fill_color=None,
+        **_filter_kwargs(kwargs, artist_kws),
+    )
+
+
+@expand_aesthetic_aliases
+def contourf(
+    x, y, density, target, *, levels=None, color=unset, alpha=unset, cmap=None, **artist_kws
+):
+    """Interface to bokeh for a filled contour plot.
+
+    Parameters
+    ----------
+    x : array_like of shape (nx,)
+        Grid values along the x axis.
+    y : array_like of shape (ny,)
+        Grid values along the y axis.
+    density : array_like of shape (nx, ny)
+        Density values on the grid.
+    target : bokeh Figure
+        The :term:`plot` to draw on.
+    levels : array_like, optional
+        Density values bounding filled regions.
+    color, alpha : any, optional
+        See :ref:`backend_interface_arguments` for details.
+    cmap : str, optional
+        Bokeh palette function name (e.g. ``"viridis"``, ``"magma"``). Overrides `color` when set.
+    **artist_kws
+        Passed to :meth:`~bokeh.plotting.figure.patches`.
+
+    Returns
+    -------
+    GlyphRenderer
+    """
+    from bokeh import palettes as bp
+
+    levels = np.asarray(levels)
+    n_bands = len(levels) - 1
+
+    if cmap is not None:
+        band_colors = list(getattr(bp, cmap)(n_bands))
+    elif color is not unset:
+        band_colors = [color] * n_bands
+
+    return target.contour(
+        x=np.asarray(x),
+        y=np.asarray(y),
+        z=np.asarray(density).T,
+        levels=[float(lv) for lv in levels],
+        fill_color=band_colors,
+        line_color=None,
+        **_filter_kwargs({"fill_alpha": alpha}, artist_kws),
+    )

--- a/src/arviz_plots/backend/matplotlib/__init__.py
+++ b/src/arviz_plots/backend/matplotlib/__init__.py
@@ -2,6 +2,8 @@
 
 from .core import (
     ciliney,
+    contour,
+    contourf,
     create_plotting_grid,
     fill_between_y,
     get_background_color,

--- a/src/arviz_plots/backend/matplotlib/core.py
+++ b/src/arviz_plots/backend/matplotlib/core.py
@@ -679,3 +679,21 @@ def yscale(target, scale):
 def grid(target, axis, color):
     """Interface to matplotlib for setting a grid in any axis."""
     target.grid(axis=axis, color=color)
+
+
+@expand_aesthetic_aliases
+def contour(x, y, density, target, *, levels=None, color=unset, alpha=unset, **artist_kws):
+    """Interface to matplotlib for a contour plot."""
+    kwargs = {"colors": color, "alpha": alpha}
+    return target.contour(
+        x, y, density.T, levels=levels, **_filter_kwargs(kwargs, None, artist_kws)
+    )
+
+
+@expand_aesthetic_aliases
+def contourf(x, y, density, target, *, levels=None, color=unset, alpha=unset, **artist_kws):
+    """Interface to matplotlib for a filled contour plot."""
+    kwargs = {"colors": color, "alpha": alpha}
+    return target.contourf(
+        x, y, density.T, levels=levels, **_filter_kwargs(kwargs, None, artist_kws)
+    )

--- a/src/arviz_plots/backend/none/__init__.py
+++ b/src/arviz_plots/backend/none/__init__.py
@@ -2,6 +2,8 @@
 
 from .core import (
     ciliney,
+    contour,
+    contourf,
     create_plotting_grid,
     fill_between_y,
     get_background_color,

--- a/src/arviz_plots/backend/none/core.py
+++ b/src/arviz_plots/backend/none/core.py
@@ -786,3 +786,81 @@ def grid(target, axis, color):
     }
     target.append(artist_element)
     return artist_element
+
+
+def contour(x, y, density, target, *, levels=None, color=unset, alpha=unset, **artist_kws):
+    """Interface for a contour plot.
+
+    Parameters
+    ----------
+    x : array_like of shape (nx,)
+        Grid values along the x axis.
+    y : array_like of shape (ny,)
+        Grid values along the y axis.
+    density : array_like of shape (nx, ny)
+        Density values on the grid.
+    target : list
+        The :term:`plot` to draw on.
+    levels : array_like, optional
+        Density values at which to draw contour lines.
+    color, alpha : any, optional
+        See :ref:`backend_interface_arguments` for details.
+    **artist_kws
+        Extra keyword arguments.
+
+    Returns
+    -------
+    dict
+    """
+    kwargs = {"color": color, "alpha": alpha, "levels": levels}
+    if not ALLOW_KWARGS and artist_kws:
+        raise ValueError(f"artist_kws not empty: {artist_kws}")
+    artist_element = {
+        "function": "contour",
+        "x": x,
+        "y": y,
+        "density": density,
+        **_filter_kwargs(kwargs, artist_kws),
+    }
+    target.append(artist_element)
+    return artist_element
+
+
+def contourf(
+    x, y, density, target, *, levels=None, color=unset, alpha=unset, cmap=None, **artist_kws
+):
+    """Interface for a filled contour plot.
+
+    Parameters
+    ----------
+    x : array_like of shape (nx,)
+        Grid values along the x axis.
+    y : array_like of shape (ny,)
+        Grid values along the y axis.
+    density : array_like of shape (nx, ny)
+        Density values on the grid.
+    target : list
+        The :term:`plot` to draw on.
+    levels : array_like, optional
+        Density values bounding filled regions.
+    color, alpha : any, optional
+        See :ref:`backend_interface_arguments` for details.
+    **artist_kws
+        Extra keyword arguments.
+
+    Returns
+    -------
+    dict
+    """
+    kwargs = {"color": color, "alpha": alpha, "levels": levels, "cmap": cmap}
+    if not ALLOW_KWARGS and artist_kws:
+        raise ValueError(f"artist_kws not empty: {artist_kws}")
+    artist_element = {
+        "function": "contourf",
+        "x": x,
+        "y": y,
+        "density": density,
+        **_filter_kwargs(kwargs, artist_kws),
+    }
+    target.append(artist_element)
+    return artist_element

--- a/src/arviz_plots/backend/plotly/__init__.py
+++ b/src/arviz_plots/backend/plotly/__init__.py
@@ -2,6 +2,8 @@
 
 from .core import (
     ciliney,
+    contour,
+    contourf,
     create_plotting_grid,
     fill_between_y,
     get_background_color,

--- a/src/arviz_plots/backend/plotly/core.py
+++ b/src/arviz_plots/backend/plotly/core.py
@@ -12,6 +12,7 @@ import re
 import warnings
 
 import numpy as np
+import plotly.colors as pc
 import plotly.graph_objects as go
 import plotly.io as pio
 from plotly.subplots import make_subplots
@@ -1016,14 +1017,12 @@ def contourf(
 
     Parameters
     ----------
-    x : array_like of shape (nx,)
-        Grid values along the x axis.
-    y : array_like of shape (ny,)
-        Grid values along the y axis.
+    x, y : array_like
+        Grid values along each axis.
     density : array_like of shape (nx, ny)
         Density values on the grid.
     target : PlotlyPlot
-        The :term:`plot` to draw on.
+        The plot to draw on.
     levels : array_like, optional
         Density values bounding filled regions.
     color, alpha : any, optional
@@ -1038,29 +1037,33 @@ def contourf(
     go.Contour
     """
     levels = np.asarray(levels)
-    density = np.asarray(density)
-    density_masked = np.where(density < levels[0], np.nan, density)
+    density_masked = np.where(density < levels[0], np.nan, np.asarray(density))
+
+    l_0, l_n = float(levels[0]), float(levels[-1])
+    n_bands = len(levels) - 1
 
     if cmap is not None:
-        colorscale = cmap
-    elif color is not unset:
-        colorscale = [[0, color], [1, color]]
+        band_colors = pc.sample_colorscale(
+            cmap, [(2 * i + 1) / (2 * n_bands) for i in range(n_bands)]
+        )
+    else:
+        band_colors = [color] * n_bands
 
-    n_bands = len(levels) - 1
+    boundaries = (levels[1:-1] - l_0) / (l_n - l_0)
+    colorscale = [[0.0, band_colors[0]]]
+    for p, c0, c1 in zip(boundaries, band_colors, band_colors[1:]):
+        colorscale += [[p - 1e-9, c0], [p, c1]]
+    colorscale.append([1.0, band_colors[-1]])
+
     trace = go.Contour(
         x=np.asarray(x),
         y=np.asarray(y),
         z=density_masked.T,
         colorscale=colorscale,
-        zmin=float(levels[0]),
-        zmax=float(levels[-1]),
+        zmin=l_0,
+        zmax=l_n,
         autocontour=False,
-        contours={
-            "showlines": False,
-            "start": float(levels[0]),
-            "end": float(levels[-1]),
-            "size": float(levels[-1] - levels[0]) / n_bands,
-        },
+        line={"width": 0},
         showscale=False,
         **_filter_kwargs({"opacity": alpha, "showlegend": False}, artist_kws),
     )

--- a/src/arviz_plots/backend/plotly/core.py
+++ b/src/arviz_plots/backend/plotly/core.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 """Plotly interface layer.
 
 Notes
@@ -953,3 +954,115 @@ def grid(target, axis="both", color=unset, **artist_kws):
         target.update_yaxes(_filter_kwargs(kwargs, artist_kws))
     if axis in ["x", "both"]:
         target.update_xaxes(_filter_kwargs(kwargs, artist_kws))
+
+
+@expand_aesthetic_aliases
+def contour(x, y, density, target, *, levels=None, color=unset, alpha=unset, **artist_kws):
+    """Interface to plotly for a contour plot.
+
+    Parameters
+    ----------
+    x : array_like of shape (nx,)
+        Grid values along the x axis.
+    y : array_like of shape (ny,)
+        Grid values along the y axis.
+    density : array_like of shape (nx, ny)
+        Density values on the grid.
+    target : PlotlyPlot
+        The :term:`plot` to draw on.
+    levels : array_like, optional
+        Density values at which to draw contour lines.
+    color, alpha : any, optional
+        See :ref:`backend_interface_arguments` for details.
+    **artist_kws
+        Passed to :class:`~plotly.graph_objects.Contour`.
+
+    Returns
+    -------
+    list of go.Contour
+    """
+    d_range = float(np.nanmax(density) - np.nanmin(density))
+    eps = d_range * 1e-6 if d_range > 0 else 1e-10
+    line_kwargs = {"color": color}
+    traces = []
+    for level in np.atleast_1d(levels):
+        lv = float(level)
+        trace = go.Contour(
+            x=np.asarray(x),
+            y=np.asarray(y),
+            z=np.asarray(density).T,
+            autocontour=False,
+            contours={
+                "coloring": "none",
+                "showlines": True,
+                "start": lv - eps,
+                "end": lv + eps,
+                "size": 2 * eps,
+            },
+            line=_filter_kwargs(line_kwargs, {}),
+            showscale=False,
+            **_filter_kwargs({"opacity": alpha, "showlegend": False}, artist_kws),
+        )
+        target.add_trace(trace)
+        traces.append(trace)
+    return traces
+
+
+@expand_aesthetic_aliases
+def contourf(
+    x, y, density, target, *, levels=None, color=unset, alpha=unset, cmap=None, **artist_kws
+):
+    """Interface to plotly for a filled contour plot.
+
+    Parameters
+    ----------
+    x : array_like of shape (nx,)
+        Grid values along the x axis.
+    y : array_like of shape (ny,)
+        Grid values along the y axis.
+    density : array_like of shape (nx, ny)
+        Density values on the grid.
+    target : PlotlyPlot
+        The :term:`plot` to draw on.
+    levels : array_like, optional
+        Density values bounding filled regions.
+    color, alpha : any, optional
+        See :ref:`backend_interface_arguments` for details.
+    cmap : str, optional
+        Plotly colorscale name. Overrides `color` when set.
+    **artist_kws
+        Passed to :class:`~plotly.graph_objects.Contour`.
+
+    Returns
+    -------
+    go.Contour
+    """
+    levels = np.asarray(levels)
+    density = np.asarray(density)
+    density_masked = np.where(density < levels[0], np.nan, density)
+
+    if cmap is not None:
+        colorscale = cmap
+    elif color is not unset:
+        colorscale = [[0, color], [1, color]]
+
+    n_bands = len(levels) - 1
+    trace = go.Contour(
+        x=np.asarray(x),
+        y=np.asarray(y),
+        z=density_masked.T,
+        colorscale=colorscale,
+        zmin=float(levels[0]),
+        zmax=float(levels[-1]),
+        autocontour=False,
+        contours={
+            "showlines": False,
+            "start": float(levels[0]),
+            "end": float(levels[-1]),
+            "size": float(levels[-1] - levels[0]) / n_bands,
+        },
+        showscale=False,
+        **_filter_kwargs({"opacity": alpha, "showlegend": False}, artist_kws),
+    )
+    target.add_trace(trace)
+    return trace

--- a/src/arviz_plots/plots/ecdf_plot.py
+++ b/src/arviz_plots/plots/ecdf_plot.py
@@ -293,6 +293,7 @@ def plot_ecdf_pit(
             **pc_kwargs,
         )
 
+    print(pc_kwargs["figure_kwargs"])
     aes_by_visuals = validate_dict_argument(aes_by_visuals, (plot_ecdf_pit, "aes_by_visuals"))
 
     ## reference line

--- a/src/arviz_plots/plots/ecdf_plot.py
+++ b/src/arviz_plots/plots/ecdf_plot.py
@@ -293,7 +293,6 @@ def plot_ecdf_pit(
             **pc_kwargs,
         )
 
-    print(pc_kwargs["figure_kwargs"])
     aes_by_visuals = validate_dict_argument(aes_by_visuals, (plot_ecdf_pit, "aes_by_visuals"))
 
     ## reference line

--- a/src/arviz_plots/plots/pair_plot.py
+++ b/src/arviz_plots/plots/pair_plot.py
@@ -359,26 +359,6 @@ def plot_pair(
             **scatter_kwargs,
         )
 
-    contour_kwargs = get_visual_kwargs(visuals, "contour", False)
-    if contour_kwargs is not False:
-        _, contour_aes, contour_ignore = filter_aes(
-            plot_matrix, aes_by_visuals, "contour", sample_dims
-        )
-
-        if "color" not in contour_aes:
-            contour_kwargs.setdefault("color", "C0")
-
-        plot_matrix.map_triangle(
-            _kde_couple,
-            "contour",
-            triangle=triangle,
-            data=distribution,
-            ignore_aes=contour_ignore,
-            levels=levels,
-            sample_dims=sample_dims,
-            **contour_kwargs,
-        )
-
     contourf_kwargs = get_visual_kwargs(visuals, "contourf", False)
     if contourf_kwargs is not False:
         _, contourf_aes, contourf_ignore = filter_aes(
@@ -400,6 +380,26 @@ def plot_pair(
             levels=levels,
             sample_dims=sample_dims,
             **contourf_kwargs,
+        )
+
+    contour_kwargs = get_visual_kwargs(visuals, "contour", False)
+    if contour_kwargs is not False:
+        _, contour_aes, contour_ignore = filter_aes(
+            plot_matrix, aes_by_visuals, "contour", sample_dims
+        )
+
+        if "color" not in contour_aes:
+            contour_kwargs.setdefault("color", "C0")
+
+        plot_matrix.map_triangle(
+            _kde_couple,
+            "contour",
+            triangle=triangle,
+            data=distribution,
+            ignore_aes=contour_ignore,
+            levels=levels,
+            sample_dims=sample_dims,
+            **contour_kwargs,
         )
     # marginal
     if marginal is not False:

--- a/src/arviz_plots/plots/pair_plot.py
+++ b/src/arviz_plots/plots/pair_plot.py
@@ -9,6 +9,7 @@ import xarray as xr
 from arviz_base import rcParams, xarray_sel_iter
 from arviz_base.labels import BaseLabeller
 from arviz_base.validate import validate_dict_argument, validate_sample_dims
+from arviz_stats import kde2d
 
 from arviz_plots.plot_matrix import PlotMatrix
 from arviz_plots.plots.dist_plot import plot_dist
@@ -20,6 +21,8 @@ from arviz_plots.plots.utils import (
     set_grid_layout,
 )
 from arviz_plots.visuals import (
+    contour,
+    contourf,
     label_plot,
     labelled_x,
     labelled_y,
@@ -37,6 +40,7 @@ def plot_pair(
     group="posterior",
     coords=None,
     sample_dims=None,
+    levels=None,
     marginal=True,
     marginal_kind=None,
     triangle="lower",
@@ -46,6 +50,8 @@ def plot_pair(
     aes_by_visuals: Mapping[
         Literal[
             "scatter",
+            "contour",
+            "contourf",
             "divergence",
             "dist",
             "credible_interval",
@@ -60,6 +66,8 @@ def plot_pair(
     visuals: Mapping[
         Literal[
             "scatter",
+            "contour",
+            "contourf",
             "divergence",
             "dist",
             "credible_interval",
@@ -102,6 +110,10 @@ def plot_pair(
     sample_dims : iterable, optional
         Dimensions to reduce unless mapped to an aesthetic.
         Defaults to ``rcParams["data.sample_dims"]``
+    levels : int or list of float, optional
+        If int, number of contour levels to show (it must be a positive integer).
+        If list of float, the probability mass to be contained for each contour level.
+        Defaults to [0.25, 0.5, 0.9]. Ignored if `visuals["contour"]` is False.
     marginal : bool, default True
         Whether to plot marginal distributions on the diagonal.
     marginal_kind : {"kde", "hist", "ecdf", "dot"}, optional
@@ -121,6 +133,7 @@ def plot_pair(
         Valid keys are:
 
         * scatter -> passed to :func:`~.visuals.scatter_couple`
+        * contour -> passed to :func:`~.visuals.contour`. Defaults to False.
         * divergence -> passed to :func:`~.visuals.scatter_couple`. Defaults to False.
         * dist -> depending on the value of `marginal_kind` passed to:
 
@@ -200,6 +213,20 @@ def plot_pair(
         >>>     triangle="upper",
         >>> )
 
+    Same as previous example, but with ``contourf`` enabled and ``scatter`` disabled.
+
+    .. plot::
+        :context: close-figs
+
+        >>> plot_pair(
+        >>>     dt,
+        >>>     var_names=["mu", "tau"],
+        >>>     visuals={"divergence": True, "contourf": True, "scatter": False},
+        >>>     marginal=True,
+        >>>     marginal_kind="ecdf",
+        >>>     triangle="upper",
+        >>> )
+
     plot_pair with `triangle` set to "both", so in this case the ``xlabels`` are mapped to the
     bottom-most plots and ``ylabels`` are mapped to the left-most plots. In this example we set
     ``color`` as "red" for ``credible_interval`` and ``point_estimate``, which enables
@@ -248,6 +275,19 @@ def plot_pair(
         else:
             backend = plot_matrix.backend
 
+    if levels is None:
+        levels = [0.25, 0.5, 0.9]
+    if isinstance(levels, int):
+        if levels <= 0:
+            raise ValueError("If levels is an integer, it must be a positive integer.")
+    elif isinstance(levels, Sequence):
+        if not all(0 < level < 1 for level in levels):
+            raise ValueError("If levels is a sequence, all values must be between 0 and 1.")
+    else:
+        raise ValueError(
+            "Levels must be either an integer or a sequence of floats between 0 and 1."
+        )
+
     distribution = process_group_variables_coords(
         dt, group=group, var_names=var_names, filter_vars=filter_vars, coords=coords
     )
@@ -286,6 +326,8 @@ def plot_pair(
     aes_by_visuals["scatter"] = {"overlay"}.union(
         aes_by_visuals.get("scatter", plot_matrix.aes_set)
     )
+    aes_by_visuals["contour"] = aes_by_visuals.get("contour", {})
+    aes_by_visuals["contourf"] = aes_by_visuals.get("contourf", {})
     aes_by_visuals["divergence"] = {"overlay"}.union(aes_by_visuals.get("divergence", {}))
     aes_by_visuals["dist"] = aes_by_visuals.get("dist", plot_matrix.aes_set.difference({"overlay"}))
     aes_by_visuals["credible_interval"] = aes_by_visuals.get("credible_interval", {})
@@ -317,6 +359,48 @@ def plot_pair(
             **scatter_kwargs,
         )
 
+    contour_kwargs = get_visual_kwargs(visuals, "contour", False)
+    if contour_kwargs is not False:
+        _, contour_aes, contour_ignore = filter_aes(
+            plot_matrix, aes_by_visuals, "contour", sample_dims
+        )
+
+        if "color" not in contour_aes:
+            contour_kwargs.setdefault("color", "C0")
+
+        plot_matrix.map_triangle(
+            _kde_couple,
+            "contour",
+            triangle=triangle,
+            data=distribution,
+            ignore_aes=contour_ignore,
+            levels=levels,
+            sample_dims=sample_dims,
+            **contour_kwargs,
+        )
+
+    contourf_kwargs = get_visual_kwargs(visuals, "contourf", False)
+    if contourf_kwargs is not False:
+        _, contourf_aes, contourf_ignore = filter_aes(
+            plot_matrix, aes_by_visuals, "contourf", sample_dims
+        )
+
+        if "color" not in contourf_aes:
+            contourf_kwargs.setdefault("cmap", "viridis")
+        else:
+            contourf_kwargs.setdefault("cmap", None)
+
+        plot_matrix.map_triangle(
+            _kde_couple,
+            "contourf",
+            triangle=triangle,
+            data=distribution,
+            ignore_aes=contourf_ignore,
+            filled=True,
+            levels=levels,
+            sample_dims=sample_dims,
+            **contourf_kwargs,
+        )
     # marginal
     if marginal is not False:
         if stats is None:
@@ -508,3 +592,44 @@ def plot_pair(
                 ignore_aes=remove_axis_ignore,
             )
     return plot_matrix
+
+
+def _kde_couple(da_x, da_y, target, filled=False, levels=None, sample_dims=None, **kw):
+    if isinstance(levels, int):
+        n_levels = levels
+        hdi_probs = None
+    else:
+        hdi_probs = np.sort(levels)[::-1]
+        n_levels = None
+
+    result = kde2d(da_x, da_y, dim=sample_dims, hdi_probs=hdi_probs)
+
+    if n_levels is not None and "contours" not in result:
+        density_vals = result["density"].values
+        contour_levels = np.linspace(
+            np.nanmin(density_vals), np.nanmax(density_vals), n_levels + 2
+        )[1:-1]
+        result = result.assign({"contours": xr.DataArray(contour_levels, dims=["level"])})
+
+    if filled:
+        max_density = float(np.nanmax(result["density"].values))
+        new_values = np.append(result["contours"].values, max_density)
+        result = result.drop_vars("contours").assign(
+            {"contours": xr.DataArray(new_values, dims=["level"])}
+        )
+        return contourf(
+            result["x_coords"],
+            result["y_coords"],
+            result["density"],
+            target,
+            levels=result["contours"],
+            **kw,
+        )
+    return contour(
+        result["x_coords"],
+        result["y_coords"],
+        result["density"],
+        target,
+        levels=result["contours"],
+        **kw,
+    )

--- a/src/arviz_plots/plots/pair_plot.py
+++ b/src/arviz_plots/plots/pair_plot.py
@@ -389,7 +389,7 @@ def plot_pair(
         )
 
         if "color" not in contour_aes:
-            contour_kwargs.setdefault("color", "C0")
+            contour_kwargs.setdefault("color", "B1")
 
         plot_matrix.map_triangle(
             _kde_couple,

--- a/src/arviz_plots/visuals/__init__.py
+++ b/src/arviz_plots/visuals/__init__.py
@@ -214,6 +214,18 @@ def scatter_couple(da_x, da_y, target, mask=None, **kwargs):
     return plot_backend.scatter(da_x.values, da_y.values, target, **kwargs)
 
 
+def contour(x_coords, y_coords, density, target, *, levels=None, **kwargs):
+    """Plot 2D KDE contours for a pairplot couple."""
+    plot_backend = backend_from_object(target)
+    plot_backend.contour(x_coords, y_coords, density, target, levels=levels, **kwargs)
+
+
+def contourf(x_coords, y_coords, density, target, *, levels=None, cmap=None, **kwargs):
+    """Plot 2D KDE filled contours for a pairplot couple."""
+    plot_backend = backend_from_object(target)
+    plot_backend.contourf(x_coords, y_coords, density, target, levels=levels, cmap=cmap, **kwargs)
+
+
 def ecdf_line(values, target, **kwargs):
     """Plot a step line."""
     plot_backend = backend_from_object(target)

--- a/tests/test_hypothesis_plots.py
+++ b/tests/test_hypothesis_plots.py
@@ -838,6 +838,8 @@ def test_plot_mcse(datatree, rug, n_points, extra_methods, visuals):
         optional={
             "scatter": visuals_value_no_false,
             "divergence": visuals_value,
+            "contour": visuals_value,
+            "contourf": visuals_value,
             "xlabel": visuals_value,
             "ylabel": visuals_value,
             "credible_interval": visuals_value,

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -617,6 +617,35 @@ class TestPlots:  # pylint: disable=too-many-public-methods
                     else:
                         assert pc.viz.scatter[row_no, col_no].values[0] is None
 
+    @pytest.mark.parametrize("levels", (10, [0.1, 0.5, 0.9]))
+    def test_plot_pair_levels(self, datatree, levels, backend):
+        visuals = {"contour": True, "contourf": True}
+        pc = plot_pair(
+            datatree,
+            var_names=["mu", "tau", "theta"],
+            coords={"hierarchy": 0},
+            marginal=True,
+            marginal_kind="kde",
+            triangle="both",
+            levels=levels,
+            visuals=visuals,
+            backend=backend,
+        )
+        assert "figure" in pc.viz.data_vars
+        assert "contour" in pc.viz.data_vars
+        assert "contourf" in pc.viz.data_vars
+        assert "scatter" in pc.viz.data_vars
+        assert "xlabel" in pc.viz.data_vars
+        assert "ylabel" in pc.viz.data_vars
+        assert "chain" in pc.viz["scatter"].dims
+        assert "chain" not in pc.viz["xlabel"].dims
+        assert "chain" not in pc.viz["ylabel"].dims
+        assert "col_index" in pc.viz["xlabel"].dims
+        assert "row_index" in pc.viz["ylabel"].dims
+        assert pc.viz["contour"].dims == ("row_index", "col_index")
+        assert pc.viz["contourf"].dims == ("row_index", "col_index")
+        assert pc.viz["scatter"].dims == ("row_index", "col_index", "chain")
+
     def test_plot_pair_sample(self, datatree_sample, backend):
         visuals = {"divergence": True}
         sample_dims = ["sample"]


### PR DESCRIPTION
This adds 2D KDE to plot_pair, but also more basic functions like contour and contourf visuals. Close #344 

Depends on https://github.com/arviz-devs/arviz-stats/pull/362