### PR TITLE
Forward labeller in plot_ridge labels

### DIFF
--- a/src/arviz_plots/plots/ridge_plot.py
+++ b/src/arviz_plots/plots/ridge_plot.py
@@ -503,6 +503,7 @@ def plot_ridge(
             subset_info=True,
             coords={"column": "labels"},
             ignore_aes=lab_ignore,
+            labeller=labeller,
             **lab_kwargs,
         )
         x += 1

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -2,6 +2,7 @@
 """Test batteries-included plots."""
 import numpy as np
 import pytest
+from arviz_base.labels import MapLabeller
 
 from arviz_plots import (
     PlotCollection,
@@ -895,6 +896,31 @@ class TestPlots:  # pylint: disable=too-many-public-methods
             assert pc.aes["alpha"]["neutral_element"].item() == 0
             assert 0 in pc.aes["alpha"]["mapping"].values
             assert pseudo_dim in pc.viz["shade"].dims
+
+    def test_plot_ridge_forwards_labeller(self, datatree, backend):
+        def _get_label_text(artist, backend):
+            if backend == "matplotlib":
+                return artist.get_text()
+            if backend == "plotly":
+                return artist.text[0]
+            if backend == "none":
+                return artist["string"]
+            if backend == "bokeh":
+                return artist.data_source.data["text"][0]
+            raise ValueError(f"Unknown backend: {backend}")
+
+        labeller = MapLabeller(var_name_map={"mu": "MY_MU"})
+        pc = plot_ridge(
+            datatree,
+            var_names=["mu"],
+            labels=["__variable__"],
+            labeller=labeller,
+            backend=backend,
+        )
+        label_artist = pc.viz["variable_label"]["mu"].item()
+        assert "variable_label" in pc.viz.children
+        assert "mu" in pc.viz["variable_label"]
+        assert _get_label_text(label_artist, backend) == "MY_MU"
 
     def test_plot_trace(self, datatree, backend):
         pc = plot_trace(datatree, backend=backend)


### PR DESCRIPTION
Fixes `plot_ridge` not applying the `labeller` kwarg to ridge labels.

`plot_ridge` already accepts/constructs a labeller, and `annotate_label` already supports one, but the labeller was not forwarded in the label mapping call. This PR passes `labeller=labeller` and adds a test checking mapped labels across backends.

Validated with:
- `pytest tests/test_plots.py -k forwards_labeller`
- `tox -e check`
- manual notebook render