### PR TITLE
Forward labeller in plot_forest labels

### DIFF
--- a/src/arviz_plots/plots/forest_plot.py
+++ b/src/arviz_plots/plots/forest_plot.py
@@ -478,6 +478,7 @@ def plot_forest(
             subset_info=True,
             coords={"column": "labels"},
             ignore_aes=lab_ignore,
+            labeller=labeller,
             **lab_kwargs,
         )
         x += 1

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -2,6 +2,7 @@
 """Test batteries-included plots."""
 import numpy as np
 import pytest
+from arviz_base.labels import MapLabeller
 
 from arviz_plots import (
     PlotCollection,
@@ -389,6 +390,32 @@ class TestPlots:  # pylint: disable=too-many-public-methods
             assert pc.aes["alpha"]["neutral_element"].item() == 0
             assert 0 in pc.aes["alpha"]["mapping"].values
             assert pseudo_dim in pc.viz["shade"].dims
+
+    def test_plot_forest_forwards_labeller(self, datatree, backend):
+        def _get_label_text(artist, backend):
+            if backend == "matplotlib":
+                return artist.get_text()
+            if backend == "plotly":
+                return artist.text[0]
+            if backend == "none":
+                return artist["string"]
+            if backend == "bokeh":
+                return artist.data_source.data["text"][0]
+            raise ValueError(f"Unknown backend: {backend}")
+
+        labeller = MapLabeller(var_name_map={"mu": "MY_MU"})
+        pc = plot_forest(
+            datatree,
+            var_names=["mu"],
+            labels=["__variable__"],
+            labeller=labeller,
+            backend=backend,
+        )
+
+        label_artist = pc.viz["variable_label"]["mu"].item()
+        assert "variable_label" in pc.viz.children
+        assert "mu" in pc.viz["variable_label"]
+        assert _get_label_text(label_artist, backend) == "MY_MU"
 
     @pytest.mark.parametrize(
         "visuals,expected_children,unexpected_children",


### PR DESCRIPTION
Fix `plot_forest` labeller being forwarded to `annotate_label` map. 

This is an almost identical fix to #504 but for forest plot instead of ridge. 

Same tests has been performed to verify functionality:

- pytest (new test written for forest plot label text)
- tox check
- manual rendering in notebook

Additionally, #505 would indeed be useful. This will require rewrite of test performed here and the ones written for #504 once #505 is realized. 