### PR TITLE
plot_pair_focus: support extra dimensions

### DIFF
--- a/src/arviz_plots/plots/pair_focus_plot.py
+++ b/src/arviz_plots/plots/pair_focus_plot.py
@@ -150,7 +150,7 @@ def plot_pair_focus(
             f"focus_var should be a string or DataArray, got {type(focus_var)} instead."
         )
 
-    dims_y = [dim for dim in y.dims if dim not in sample_dims]
+    dims_y = [dim for dim in y.dims if dim not in distribution.dims]
     if len(dims_y) > 0:
         raise ValueError(f"focus variable has unexpected dimensions: {dims_y}.")
 


### PR DESCRIPTION
For instance, we may want to do 

```python
idata_0 = az.load_arviz_data("centered_eight")
idata_1 = az.load_arviz_data("non_centered_eight")

combined = xr.concat(
    [idata_0, idata_1],
    dim=xr.DataArray(["model_0", "model_1"], dims="__model__")
)

az.plot_pair_focus(combined, var_names=["mu"], focus_var="tau")
```
to get 

<img width="2423" height="559" alt="output" src="https://github.com/user-attachments/assets/70421dab-7ebf-4c98-ab4c-407612bca315" />
