### PR TITLE
Bring arviz-darkgrid style back  

### DIFF
--- a/src/arviz_plots/__init__.py
+++ b/src/arviz_plots/__init__.py
@@ -325,6 +325,7 @@ try:
         arviz_variat_template,
         arviz_vibrant_template,
         arviz_tumma_template,
+        arviz_darkgrid_template,
     )
 
     pio.templates["arviz-cetrino"] = arviz_cetrino_template
@@ -332,6 +333,7 @@ try:
     pio.templates["arviz-variat"] = arviz_variat_template
     pio.templates["arviz-vibrant"] = arviz_vibrant_template
     pio.templates["arviz-tumma"] = arviz_tumma_template
+    pio.templates["arviz-darkgrid"] = arviz_darkgrid_template
 
 
 except ImportError:

--- a/src/arviz_plots/backend/bokeh/core.py
+++ b/src/arviz_plots/backend/bokeh/core.py
@@ -130,8 +130,6 @@ def _set_sqrt_scale(target, axis):
 
 def get_hex_from_color_name(color_name: str) -> str:
     """Convert a standard CSS color name into its HEX code using Bokeh."""
-    if isinstance(color_name, str) and color_name.startswith("#"):
-        return color_name
     try:
         color_obj: Color = getattr(named_colors, color_name.lower())
         return color_obj.to_hex()
@@ -146,8 +144,9 @@ def get_background_color():
         from bokeh.io import curdoc
 
         bg_color = curdoc().theme._json["attrs"]["Plot"]["background_fill_color"]
-        hex_bg_color = get_hex_from_color_name(bg_color)
-        return hex_bg_color
+        if isinstance(bg_color, str) and bg_color.startswith("#"):
+            return bg_color
+        return get_hex_from_color_name(bg_color)
     except (ImportError, KeyError):
         return "#ffffff"
 
@@ -507,21 +506,49 @@ def hist(
         if edgecolor is unset:
             edgecolor = color
 
-    kwargs = {"bottom": bottom, "fill_color": facecolor, "line_color": edgecolor, "alpha": alpha}
+    kwargs = {
+        "bottom": bottom,
+        "fill_color": facecolor,
+        "line_color": edgecolor,
+        "alpha": alpha,
+    }
 
     return target.quad(top=y, left=l_e, right=r_e, **_filter_kwargs(kwargs, artist_kws))
 
 
 @expand_aesthetic_aliases
-def line(x, y, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
+def line(
+    x,
+    y,
+    target,
+    *,
+    color=unset,
+    alpha=unset,
+    width=unset,
+    linestyle=unset,
+    **artist_kws,
+):
     """Interface to bokeh for a line plot."""
-    kwargs = {"color": color, "alpha": alpha, "line_width": width, "line_dash": linestyle}
+    kwargs = {
+        "color": color,
+        "alpha": alpha,
+        "line_width": width,
+        "line_dash": linestyle,
+    }
     return target.line(np.atleast_1d(x), np.atleast_1d(y), **_filter_kwargs(kwargs, artist_kws))
 
 
 @expand_aesthetic_aliases
 def multiple_lines(
-    x, y, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws
+    x,
+    y,
+    target,
+    *,
+    color=unset,
+    alpha=unset,
+    width=unset,
+    linestyle=unset,
+    **artist_kws,
 ):
     """Interface to bokeh for multiple lines."""
     y = y.T
@@ -530,7 +557,12 @@ def multiple_lines(
     if len(x) != len(y):
         raise ValueError("x and y must have the same length")
     source = ColumnDataSource(data={"x": x, "y": y})
-    kwargs = {"line_color": color, "line_alpha": alpha, "line_width": width, "line_dash": linestyle}
+    kwargs = {
+        "line_color": color,
+        "line_alpha": alpha,
+        "line_width": width,
+        "line_dash": linestyle,
+    }
     return target.multi_line(xs="x", ys="y", source=source, **_filter_kwargs(kwargs, artist_kws))
 
 
@@ -646,7 +678,12 @@ def fill_between_y(x, y_bottom, y_top, target, **artist_kws):
 @expand_aesthetic_aliases
 def vline(x, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
     """Interface to bokeh for a vertical line spanning the whole axes."""
-    kwargs = {"line_color": color, "line_alpha": alpha, "line_width": width, "line_dash": linestyle}
+    kwargs = {
+        "line_color": color,
+        "line_alpha": alpha,
+        "line_width": width,
+        "line_dash": linestyle,
+    }
     span_element = Span(location=x, dimension="height", **_filter_kwargs(kwargs, artist_kws))
     target.add_layout(span_element)
     return span_element
@@ -655,7 +692,12 @@ def vline(x, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, 
 @expand_aesthetic_aliases
 def hline(y, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
     """Interface to bokeh for a horizontal line spanning the whole axes."""
-    kwargs = {"line_color": color, "line_alpha": alpha, "line_width": width, "line_dash": linestyle}
+    kwargs = {
+        "line_color": color,
+        "line_alpha": alpha,
+        "line_width": width,
+        "line_dash": linestyle,
+    }
     span_element = Span(location=y, dimension="width", **_filter_kwargs(kwargs, artist_kws))
     target.add_layout(span_element)
     return span_element
@@ -693,7 +735,12 @@ def ciliney(
     **artist_kws,
 ):
     """Interface to bokeh for a line from y_bottom to y_top at given value of x."""
-    kwargs = {"color": color, "alpha": alpha, "line_width": width, "line_dash": linestyle}
+    kwargs = {
+        "color": color,
+        "alpha": alpha,
+        "line_width": width,
+        "line_dash": linestyle,
+    }
     x = np.atleast_1d(x)
     y_bottom = np.atleast_1d(y_bottom)
     y_top = np.atleast_1d(y_top)

--- a/src/arviz_plots/backend/bokeh/core.py
+++ b/src/arviz_plots/backend/bokeh/core.py
@@ -506,49 +506,21 @@ def hist(
         if edgecolor is unset:
             edgecolor = color
 
-    kwargs = {
-        "bottom": bottom,
-        "fill_color": facecolor,
-        "line_color": edgecolor,
-        "alpha": alpha,
-    }
+    kwargs = {"bottom": bottom, "fill_color": facecolor, "line_color": edgecolor, "alpha": alpha}
 
     return target.quad(top=y, left=l_e, right=r_e, **_filter_kwargs(kwargs, artist_kws))
 
 
 @expand_aesthetic_aliases
-def line(
-    x,
-    y,
-    target,
-    *,
-    color=unset,
-    alpha=unset,
-    width=unset,
-    linestyle=unset,
-    **artist_kws,
-):
+def line(x, y, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
     """Interface to bokeh for a line plot."""
-    kwargs = {
-        "color": color,
-        "alpha": alpha,
-        "line_width": width,
-        "line_dash": linestyle,
-    }
+    kwargs = {"color": color, "alpha": alpha, "line_width": width, "line_dash": linestyle}
     return target.line(np.atleast_1d(x), np.atleast_1d(y), **_filter_kwargs(kwargs, artist_kws))
 
 
 @expand_aesthetic_aliases
 def multiple_lines(
-    x,
-    y,
-    target,
-    *,
-    color=unset,
-    alpha=unset,
-    width=unset,
-    linestyle=unset,
-    **artist_kws,
+    x, y, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws
 ):
     """Interface to bokeh for multiple lines."""
     y = y.T
@@ -557,12 +529,7 @@ def multiple_lines(
     if len(x) != len(y):
         raise ValueError("x and y must have the same length")
     source = ColumnDataSource(data={"x": x, "y": y})
-    kwargs = {
-        "line_color": color,
-        "line_alpha": alpha,
-        "line_width": width,
-        "line_dash": linestyle,
-    }
+    kwargs = {"line_color": color, "line_alpha": alpha, "line_width": width, "line_dash": linestyle}
     return target.multi_line(xs="x", ys="y", source=source, **_filter_kwargs(kwargs, artist_kws))
 
 
@@ -678,12 +645,7 @@ def fill_between_y(x, y_bottom, y_top, target, **artist_kws):
 @expand_aesthetic_aliases
 def vline(x, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
     """Interface to bokeh for a vertical line spanning the whole axes."""
-    kwargs = {
-        "line_color": color,
-        "line_alpha": alpha,
-        "line_width": width,
-        "line_dash": linestyle,
-    }
+    kwargs = {"line_color": color, "line_alpha": alpha, "line_width": width, "line_dash": linestyle}
     span_element = Span(location=x, dimension="height", **_filter_kwargs(kwargs, artist_kws))
     target.add_layout(span_element)
     return span_element
@@ -692,12 +654,7 @@ def vline(x, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, 
 @expand_aesthetic_aliases
 def hline(y, target, *, color=unset, alpha=unset, width=unset, linestyle=unset, **artist_kws):
     """Interface to bokeh for a horizontal line spanning the whole axes."""
-    kwargs = {
-        "line_color": color,
-        "line_alpha": alpha,
-        "line_width": width,
-        "line_dash": linestyle,
-    }
+    kwargs = {"line_color": color, "line_alpha": alpha, "line_width": width, "line_dash": linestyle}
     span_element = Span(location=y, dimension="width", **_filter_kwargs(kwargs, artist_kws))
     target.add_layout(span_element)
     return span_element
@@ -735,12 +692,7 @@ def ciliney(
     **artist_kws,
 ):
     """Interface to bokeh for a line from y_bottom to y_top at given value of x."""
-    kwargs = {
-        "color": color,
-        "alpha": alpha,
-        "line_width": width,
-        "line_dash": linestyle,
-    }
+    kwargs = {"color": color, "alpha": alpha, "line_width": width, "line_dash": linestyle}
     x = np.atleast_1d(x)
     y_bottom = np.atleast_1d(y_bottom)
     y_top = np.atleast_1d(y_top)

--- a/src/arviz_plots/backend/bokeh/core.py
+++ b/src/arviz_plots/backend/bokeh/core.py
@@ -131,7 +131,7 @@ def _set_sqrt_scale(target, axis):
 def get_hex_from_color_name(color_name: str) -> str:
     """Convert a standard CSS color name into its HEX code using Bokeh."""
     if isinstance(color_name, str) and color_name.startswith("#"):
-        return color_name  # already a hex color, return unchanged
+        return color_name
     try:
         color_obj: Color = getattr(named_colors, color_name.lower())
         return color_obj.to_hex()

--- a/src/arviz_plots/backend/bokeh/core.py
+++ b/src/arviz_plots/backend/bokeh/core.py
@@ -130,6 +130,8 @@ def _set_sqrt_scale(target, axis):
 
 def get_hex_from_color_name(color_name: str) -> str:
     """Convert a standard CSS color name into its HEX code using Bokeh."""
+    if isinstance(color_name, str) and color_name.startswith("#"):
+        return color_name  # already a hex color, return unchanged
     try:
         color_obj: Color = getattr(named_colors, color_name.lower())
         return color_obj.to_hex()

--- a/src/arviz_plots/backend/bokeh/core.py
+++ b/src/arviz_plots/backend/bokeh/core.py
@@ -144,9 +144,8 @@ def get_background_color():
         from bokeh.io import curdoc
 
         bg_color = curdoc().theme._json["attrs"]["Plot"]["background_fill_color"]
-        if isinstance(bg_color, str) and bg_color.startswith("#"):
-            return bg_color
-        return get_hex_from_color_name(bg_color)
+        hex_bg_color = bg_color if bg_color.startswith("#") else get_hex_from_color_name(bg_color)
+        return hex_bg_color
     except (ImportError, KeyError):
         return "#ffffff"
 

--- a/src/arviz_plots/backend/plotly/templates.py
+++ b/src/arviz_plots/backend/plotly/templates.py
@@ -92,6 +92,37 @@ arviz_vibrant_template.layout.colorway = [
 ]
 
 
+axis_darkgrid = {
+    "showgrid": True,
+    "gridcolor": "white",
+    "zeroline": False,
+    "showline": False,
+    "ticks": "",
+}
+arviz_darkgrid_template = go.layout.Template()
+arviz_darkgrid_template.data.scatter = h_template
+arviz_darkgrid_template.data.bar = h_template
+arviz_darkgrid_template.layout.paper_bgcolor = "white"
+arviz_darkgrid_template.layout.plot_bgcolor = "#eeeeee"
+arviz_darkgrid_template.layout.polar.bgcolor = "#eeeeee"
+arviz_darkgrid_template.layout.ternary.bgcolor = "#eeeeee"
+arviz_darkgrid_template.layout.margin = {"l": 50, "r": 10, "t": 40, "b": 45}
+arviz_darkgrid_template.layout.xaxis = axis_darkgrid
+arviz_darkgrid_template.layout.yaxis = axis_darkgrid
+arviz_darkgrid_template.layout.colorway = [
+    "#2a2eec",
+    "#fa7c17",
+    "#328c06",
+    "#c10c90",
+    "#933708",
+    "#65e5f3",
+    "#e6e135",
+    "#1ccd6a",
+    "#bd8ad5",
+    "#b16b57",
+]
+
+
 axis_tumma = axis_common | {
     "linecolor": "#D9D9D9",
     "tickcolor": "#D9D9D9",

--- a/src/arviz_plots/backend/plotly/templates.py
+++ b/src/arviz_plots/backend/plotly/templates.py
@@ -118,8 +118,6 @@ arviz_darkgrid_template.layout.colorway = [
     "#65e5f3",
     "#e6e135",
     "#1ccd6a",
-    "#bd8ad5",
-    "#b16b57",
 ]
 
 

--- a/src/arviz_plots/styles/arviz-darkgrid.mplstyle
+++ b/src/arviz_plots/styles/arviz-darkgrid.mplstyle
@@ -1,0 +1,40 @@
+# This style is based on Seaborn-darkgrid parameters, the main differences are
+# Default matplotlib font (no problem using Greek letters!)
+# Larger font size for several elements
+# Colorblind friendly color cycle
+figure.figsize: 7.2, 4.8
+figure.dpi: 100.0
+figure.facecolor: white
+figure.constrained_layout.use: True
+text.color: .15
+axes.labelcolor: .15
+legend.frameon: False
+legend.numpoints: 1
+legend.scatterpoints: 1
+xtick.direction: out
+ytick.direction: out
+xtick.color: .15
+ytick.color: .15
+axes.axisbelow: True
+grid.linestyle: -
+lines.solid_capstyle: round
+
+axes.labelsize: 15
+axes.titlesize: 16
+xtick.labelsize: 14
+ytick.labelsize: 14
+legend.fontsize: 14
+
+axes.grid: True
+axes.facecolor: eeeeee
+axes.edgecolor: white
+axes.linewidth: 0
+grid.color: white
+image.cmap: viridis
+xtick.major.size: 0
+ytick.major.size: 0
+xtick.minor.size: 0
+ytick.minor.size: 0
+
+# color-blind friendly cycle designed using https://colorcyclepicker.mpetroff.net/
+axes.prop_cycle: cycler('color', ['2a2eec', 'fa7c17', '328c06', 'c10c90', '933708', '65e5f3', 'e6e135', '1ccd6a', 'bd8ad5', 'b16b57'])

--- a/src/arviz_plots/styles/arviz-darkgrid.yml
+++ b/src/arviz_plots/styles/arviz-darkgrid.yml
@@ -1,0 +1,24 @@
+attrs:
+    Plot:
+        background_fill_color: '#eeeeee'
+        border_fill_color: white
+        outline_line_width: 0
+        outline_line_color: null
+    Axis:
+        axis_line_color: white
+        major_tick_line_color: null
+        minor_tick_line_color: null
+        major_label_text_color: '#262626'
+        axis_label_text_color: '#262626'
+    Grid:
+        grid_line_color: white
+    Title:
+        text_color: '#262626'
+        align: 'center'
+    Text:
+        text_color: '#262626'
+    Cycler:
+        colors: [
+                "#2a2eec", "#fa7c17", "#328c06", "#c10c90", "#933708",
+                "#65e5f3", "#e6e135", "#1ccd6a", "#bd8ad5", "#b16b57",
+            ]

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -64,9 +64,7 @@ def test_style_registered_all_backends(style_name):
     available = style.available()
     for backend in BACKENDS:
         if backend in available:
-            assert style_name in available[backend], (
-                f"{style_name} missing for {backend}"
-            )
+            assert style_name in available[backend], f"{style_name} missing for {backend}"
     if "common" in available:
         assert style_name in available["common"]
 

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -1,0 +1,81 @@
+# pylint: disable=redefined-outer-name, import-outside-toplevel
+"""Test that every bundled arviz style registers and renders on every installed backend."""
+
+from pathlib import Path
+
+import pytest
+
+import arviz_plots as azp
+from arviz_plots import plot_dist, style
+
+STYLES_DIR = Path(azp.__file__).parent / "styles"
+# Source of truth: every style we ship a matplotlib ``.mplstyle`` for.
+# The list auto-updates when a style is added/removed.
+ARVIZ_STYLES = sorted(path.stem for path in STYLES_DIR.glob("*.mplstyle"))
+BACKENDS = ["matplotlib", "bokeh", "plotly"]
+
+
+@pytest.fixture
+def restore_style():
+    """Snapshot global style state per backend and restore it after the test.
+
+    Applying a style mutates global state (matplotlib rcParams, the default plotly
+    template and the bokeh document theme), so it must be restored to avoid leaking
+    into other tests.
+    """
+    saved = {}
+    try:
+        import matplotlib as mpl
+
+        saved["mpl"] = mpl.rcParams.copy()
+    except ImportError:
+        pass
+    try:
+        import plotly.io as pio
+
+        saved["plotly"] = pio.templates.default
+    except ImportError:
+        pass
+    try:
+        from bokeh.io import curdoc
+
+        saved["bokeh"] = curdoc().theme
+    except ImportError:
+        pass
+
+    yield
+
+    if "mpl" in saved:
+        import matplotlib as mpl
+
+        mpl.rcParams.update(saved["mpl"])
+    if "plotly" in saved:
+        import plotly.io as pio
+
+        pio.templates.default = saved["plotly"]
+    if "bokeh" in saved:
+        from bokeh.io import curdoc
+
+        curdoc().theme = saved["bokeh"]
+
+
+@pytest.mark.parametrize("style_name", ARVIZ_STYLES)
+def test_style_registered_all_backends(style_name):
+    available = style.available()
+    for backend in BACKENDS:
+        if backend in available:
+            assert style_name in available[backend], (
+                f"{style_name} missing for {backend}"
+            )
+    if "common" in available:
+        assert style_name in available["common"]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("style_name", ARVIZ_STYLES)
+@pytest.mark.usefixtures("restore_style", "clean_plots", "check_skips")
+def test_style_renders(datatree, style_name, backend):
+    pytest.importorskip(backend)
+    style.use(style_name)
+    pc = plot_dist(datatree, backend=backend)
+    assert "figure" in pc.viz.data_vars

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -73,7 +73,6 @@ def test_style_registered_all_backends(style_name):
 @pytest.mark.parametrize("style_name", ARVIZ_STYLES)
 @pytest.mark.usefixtures("restore_style", "clean_plots", "check_skips")
 def test_style_renders(datatree, style_name, backend):
-    pytest.importorskip(backend)
     style.use(style_name)
     pc = plot_dist(datatree, backend=backend)
     assert "figure" in pc.viz.data_vars

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -17,46 +17,22 @@ BACKENDS = ["matplotlib", "bokeh", "plotly"]
 
 @pytest.fixture
 def restore_style():
-    """Snapshot global style state per backend and restore it after the test.
+    """Revert global style state to the library defaults after each test.
 
-    Applying a style mutates global state (matplotlib rcParams, the default plotly
-    template and the bokeh document theme), so it must be restored to avoid leaking
-    into other tests.
+    ``style.use`` sets the default style/template on *every* installed backend (not just
+    the one under test), so all three are reverted to their library defaults here. No setup
+    is needed; the test matrix always installs all three backends, so the imports succeed.
     """
-    saved = {}
-    try:
-        import matplotlib as mpl
-
-        saved["mpl"] = mpl.rcParams.copy()
-    except ImportError:
-        pass
-    try:
-        import plotly.io as pio
-
-        saved["plotly"] = pio.templates.default
-    except ImportError:
-        pass
-    try:
-        from bokeh.io import curdoc
-
-        saved["bokeh"] = curdoc().theme
-    except ImportError:
-        pass
-
     yield
 
-    if "mpl" in saved:
-        import matplotlib as mpl
+    import matplotlib
+    import plotly.io as pio
+    from bokeh.io import curdoc
+    from bokeh.themes import default as default_bokeh_theme
 
-        mpl.rcParams.update(saved["mpl"])
-    if "plotly" in saved:
-        import plotly.io as pio
-
-        pio.templates.default = saved["plotly"]
-    if "bokeh" in saved:
-        from bokeh.io import curdoc
-
-        curdoc().theme = saved["bokeh"]
+    matplotlib.rcdefaults()
+    pio.templates.default = "plotly"
+    curdoc().theme = default_bokeh_theme
 
 
 @pytest.mark.parametrize("style_name", ARVIZ_STYLES)

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -16,23 +16,30 @@ BACKENDS = ["matplotlib", "bokeh", "plotly"]
 
 
 @pytest.fixture
-def restore_style():
+def restore_style(request):
     """Revert global style state to the library defaults after each test.
 
     ``style.use`` sets the default style/template on *every* installed backend (not just
-    the one under test), so all three are reverted to their library defaults here. No setup
-    is needed; the test matrix always installs all three backends, so the imports succeed.
+    the one under test), so all three are reverted to their library defaults here. Each
+    reset is gated on the matching ``--skip-<backend>`` flag (like ``check_skips``) so a
+    backend whose tests are skipped -- e.g. because it is not installed -- is never imported.
+    No setup is needed.
     """
     yield
 
-    import matplotlib
-    import plotly.io as pio
-    from bokeh.io import curdoc
-    from bokeh.themes import default as default_bokeh_theme
+    if not request.config.getoption("--skip-mpl"):
+        import matplotlib
 
-    matplotlib.rcdefaults()
-    pio.templates.default = "plotly"
-    curdoc().theme = default_bokeh_theme
+        matplotlib.rcdefaults()
+    if not request.config.getoption("--skip-plotly"):
+        import plotly.io as pio
+
+        pio.templates.default = "plotly"
+    if not request.config.getoption("--skip-bokeh"):
+        from bokeh.io import curdoc
+        from bokeh.themes import default as default_bokeh_theme
+
+        curdoc().theme = default_bokeh_theme
 
 
 @pytest.mark.parametrize("style_name", ARVIZ_STYLES)


### PR DESCRIPTION
Closes https://github.com/arviz-devs/arviz-plots/issues/510

I also added some unit-tests to verify all styles work with all backends :)

```python
import arviz_base
import arviz_plots as azp

azp.style.use("arviz-darkgrid")

idata = arviz_base.load_arviz_data("centered_eight")

pc = azp.plot_forest(idata, backend="matplotlib")
pc.viz["figure"].item();
```
<img width="1451" height="716" alt="image" src="https://github.com/user-attachments/assets/cab8f86f-5669-4cf4-bc64-382e3206a6fe" />

```python
pc = azp.plot_forest(idata, backend="plotly")
pc.viz["figure"].item();
```

<img width="817" height="598" alt="image" src="https://github.com/user-attachments/assets/a6c00e5a-eac4-4979-8146-1d3f99611104" />
