### PR TITLE
two small pre-commit setup changes:

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+- package-ecosystem: "pre-commit"
+  directory: "/"
+  schedule:
+    interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,20 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: "weekly"
+    interval: "monthly"
+  cooldown:
+    default-days: 14
+  groups:
+    actions:
+      patterns:
+        - "*"
 - package-ecosystem: "pre-commit"
   directory: "/"
   schedule:
-    interval: "weekly"
+    interval: "monthly"
+  cooldown:
+    default-days: 14
+  groups:
+    pre-commit:
+      patterns:
+        - "*"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v6.0.0
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=1500']
@@ -12,7 +12,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.18
+  rev: 01a675ea018f2fb714478a5ffb83fcea8374bb06  # frozen: v0.15.21
   hooks:
     - id: ruff-check
       args: [--fix, --exit-non-zero-on-fix]
@@ -22,7 +22,7 @@ repos:
       exclude: ^docs/source/gallery/
 
 - repo: https://github.com/MarcoGorelli/madforhooks
-  rev: 0.4.1
+  rev: 543b5e414406c00edeb9e2204141713c4c8d2404  # frozen: 0.4.1
   hooks:
     - id: no-print-statements
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,11 @@ repos:
       types: [ python ]
       exclude: ^docs/source/gallery/
 
+- repo: https://github.com/MarcoGorelli/madforhooks
+  rev: 0.4.1
+  hooks:
+    - id: no-print-statements
+
 - repo: local
   hooks:
     - id: pylint


### PR DESCRIPTION
- added the no-print-statements hook so plots matches arviz-base & arviz-stats (no print() in the code, so it passes as is)
- added pre-commit to dependabot so our hook versions update automatically, like github-actions already does