### PR TITLE
Fix mypy python_version to match project's 3.12+ requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ ban-relative-imports = "all"
 docstring-code-format = false
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 warn_redundant_casts = true
 warn_unused_configs = true
 pretty = true


### PR DESCRIPTION
 Fixes #468

   The `[tool.mypy]` python_version was set to 3.10, but the project requires Python 3.12+. Updated to match.