### PR TITLE
fix: flatten 2D arrays in scatter for plotly and bokeh backends

### DIFF
--- a/src/arviz_plots/backend/bokeh/core.py
+++ b/src/arviz_plots/backend/bokeh/core.py
@@ -570,7 +570,7 @@ def scatter(
         kwargs["marker"] = "dash"
         kwargs["angle"] = np.pi / 2
 
-    source = ColumnDataSource(data={"x": np.atleast_1d(x), "y": np.atleast_1d(y)})
+    source = ColumnDataSource(data={"x": np.atleast_1d(np.ravel(x)), "y": np.atleast_1d(np.ravel(y))})
     return target.scatter(x="x", y="y", source=source, **kwargs)
 
 

--- a/src/arviz_plots/backend/plotly/core.py
+++ b/src/arviz_plots/backend/plotly/core.py
@@ -600,8 +600,8 @@ def scatter(
     if marker == "|":
         scatter_kwargs["symbol"] = "line-ns-open"
     scatter_object = go.Scatter(
-        x=np.atleast_1d(x),
-        y=np.atleast_1d(y),
+        x=np.atleast_1d(np.ravel(x)),
+        y=np.atleast_1d(np.ravel(y)),
         mode="markers",
         marker=_filter_kwargs(scatter_kwargs, marker_artist_kws),
         **artist_kws,


### PR DESCRIPTION
## Summary

When plotting rugs (or any `scatter_x` visual) with multi-dimensional data (e.g., posterior samples with chain and draw dimensions), the `x` and `y` arrays passed to plotly's `go.Scatter` and bokeh's `ColumnDataSource` were 2D. Matplotlib's `scatter` handles 2D arrays by flattening them internally, but plotly and bokeh expect 1D arrays.

This caused rugs to not display in plotly and bokeh backends.

## Root Cause

The `scatter_x` visual function calls `plot_backend.scatter(da, y, target, **kwargs)` where `da` is the distribution data (shape: chain x draw) and `y = np.zeros_like(da)` (same shape). The matplotlib backend flattens 2D arrays automatically, but:

- **Plotly**: `go.Scatter(x=np.atleast_1d(x), ...)` -- `np.atleast_1d` does not flatten 2D arrays, so `x` and `y` remained 2D (e.g., shape 4x500)
- **Bokeh**: `ColumnDataSource(data={"x": np.atleast_1d(x), ...})` -- same issue, bokeh expects 1D arrays

## Fix

Use `np.ravel()` to flatten the arrays before passing them to plotly and bokeh scatter functions.

## Verification

- Verified that rug markers now have correct 1D shape (2000,) instead of 2D (4, 500) for both plotly and bokeh
- Matplotlib backend continues to work unchanged
- Existing tests pass (the only error is a pre-existing numpy/netCDF4 binary incompatibility unrelated to this change)

Fixes #535