### PR TITLE
doc: update deprecated git protocol to https in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Consequently, it is not recommended to install arviz-plots but instead to choose
 The latest development version can be installed from the main branch using pip:
 
 ```
-pip install git+git://github.com/arviz-devs/arviz-plots.git
+pip install git+https://github.com/arviz-devs/arviz-plots.git
 ```
 
 Another option is to clone the repository and install using git and setuptools:


### PR DESCRIPTION
### Description
This PR updates the deprecated and unencrypted `git://` protocol link in the README to the standard, secure `https://` protocol. 

### Changes Made
* **`README.md`**: Modified the repository clone URL in the installation instructions. GitHub has deprecated unencrypted Git connections, and the `git://` port is frequently blocked by strict firewalls. Updating to `https://` ensures new users and contributors can install the development build without encountering connection timeouts or security errors.

### Checklist
- [x] Changes purely target documentation/README; no public API architectural breakages.
- [x] Code adheres to the project style guidelines.