### PR TITLE
Coord aes map

### DIFF
--- a/src/arviz_plots/plot_collection.py
+++ b/src/arviz_plots/plot_collection.py
@@ -1355,7 +1355,7 @@ class PlotCollection:
         dim_to_idx = {
             data[idx].dims[0]: idx
             for idx in data.coords
-            if (idx in all_loop_dims) 
+            if (idx in all_loop_dims)
             and (idx not in data.dims)
             and (data[idx].dims[0] not in self.facet_dims)
             and (data[idx].dims[0] not in other_aes_dims)

--- a/src/arviz_plots/plot_collection.py
+++ b/src/arviz_plots/plot_collection.py
@@ -1346,10 +1346,19 @@ class PlotCollection:
             raise TypeError("data argument must be an xarray.Dataset")
 
         aes, all_loop_dims = self.update_aes(ignore_aes, coords)
+        other_aes_dims = {
+            dim
+            for aes_key in self.aes_set
+            if aes_key not in ignore_aes
+            for dim in self.aes[aes_key].dims
+        }
         dim_to_idx = {
             data[idx].dims[0]: idx
             for idx in data.coords
-            if (idx in all_loop_dims) and (idx not in data.dims)
+            if (idx in all_loop_dims) 
+            and (idx not in data.dims)
+            and (data[idx].dims[0] not in self.facet_dims)
+            and (data[idx].dims[0] not in other_aes_dims)
         }
         for idx in dim_to_idx.values():
             if idx not in data.xindexes:
@@ -1376,6 +1385,11 @@ class PlotCollection:
             except TypeError:
                 pass
             sel_plus = {**sel, **coords}
+            for _idx in data.coords:
+                if _idx in all_loop_dims and _idx not in data.dims and _idx not in sel_plus:
+                    _dim = data[_idx].dims[0]
+                    if _dim in sel:
+                        sel_plus[_idx] = data[_idx].sel({_dim: sel[_dim]}).item()
             target = self.get_target(var_name, sel_plus)
 
             aes_kwargs = self.get_aes_kwargs(aes, var_name, sel_plus)

--- a/tests/test_plot_collection.py
+++ b/tests/test_plot_collection.py
@@ -22,6 +22,7 @@ def dataset(seed=31):
         dims={"theta": ["hierarchy"], "eta": ["group", "hierarchy"]},
     )
 
+
 @pytest.fixture(scope="module")
 def dataset_grouped(seed=31):
     """Dataset with a grouping coordinate on the ``hierarchy`` dimension.
@@ -286,6 +287,7 @@ class TestAesthetics:
         assert aes_dt["color"]["mapping"].dims == ("group_of",)
         assert aes_dt["color"]["mapping"].size == 3
 
+
 class TestSaveFigures:
     @pytest.mark.parametrize(
         "backend",
@@ -547,9 +549,8 @@ class TestMap:
         kwarg_list = []
         pc.map(map_auxiliar, "mean", target_list=target_list, kwarg_list=kwarg_list)
         assert len(target_list) == 6
-        assert [kwargs["color"] for kwargs in kwarg_list] == [
-            "c0", "c0", "c1", "c1", "c2", "c2"
-        ]
+        assert [kwargs["color"] for kwargs in kwarg_list] == ["c0", "c0", "c1", "c1", "c2", "c2"]
+
 
 class TestFacetMap:
     def test_string_function(self, dataset):

--- a/tests/test_plot_collection.py
+++ b/tests/test_plot_collection.py
@@ -535,10 +535,6 @@ class TestMap:
             assert "school" not in kwargs["ds"].dims
             assert "school" not in kwargs["da_hierarchy"].dims
 
-    @pytest.mark.xfail(
-        reason="aes mapped to a non-dimension coordinate collapses iteration "
-        "granularity, breaking target resolution. See arviz-plots#551"
-    )
     def test_map_nondim_coord_aes(self, dataset_grouped):
         pc = PlotCollection.wrap(
             dataset_grouped,

--- a/tests/test_plot_collection.py
+++ b/tests/test_plot_collection.py
@@ -22,6 +22,17 @@ def dataset(seed=31):
         dims={"theta": ["hierarchy"], "eta": ["group", "hierarchy"]},
     )
 
+@pytest.fixture(scope="module")
+def dataset_grouped(seed=31):
+    """Dataset with a grouping coordinate on the ``hierarchy`` dimension.
+
+    ``group_of`` maps the 6 hierarchy coords to 3 groups, 2 each.
+    """
+    rng = np.random.default_rng(seed)
+    theta = rng.normal(size=(3, 10, 6))
+    ds = dict_to_dataset({"theta": theta}, dims={"theta": ["hierarchy"]})
+    return ds.assign_coords(group_of=("hierarchy", np.repeat(["g0", "g1", "g2"], 2)))
+
 
 @pytest.mark.parametrize("backend", ["matplotlib", "bokeh", "plotly"])
 @pytest.mark.usefixtures("clean_plots")
@@ -268,6 +279,12 @@ class TestAesthetics:
         assert aes_dt["y"]["eta"].min() == (3 + 3 * 7)
         assert aes_dt["y"]["eta"].max() == (3 + 3 * 7 + 3 * 7 * 4 - 1)
 
+    def test_aes_from_nondim_coord(self, dataset_grouped):
+        pc = PlotCollection(dataset_grouped, DataTree())
+        aes_dt = pc.generate_aes_dt(aes={"color": ["group_of"]}, color=["c0", "c1", "c2"])
+        assert "/color" in aes_dt.groups
+        assert aes_dt["color"]["mapping"].dims == ("group_of",)
+        assert aes_dt["color"]["mapping"].size == 3
 
 class TestSaveFigures:
     @pytest.mark.parametrize(
@@ -518,6 +535,25 @@ class TestMap:
             assert "school" not in kwargs["ds"].dims
             assert "school" not in kwargs["da_hierarchy"].dims
 
+    @pytest.mark.xfail(
+        reason="aes mapped to a non-dimension coordinate collapses iteration "
+        "granularity, breaking target resolution. See arviz-plots#551"
+    )
+    def test_map_nondim_coord_aes(self, dataset_grouped):
+        pc = PlotCollection.wrap(
+            dataset_grouped,
+            cols=["hierarchy"],
+            backend="none",
+            aes={"color": ["group_of"]},
+            color=["c0", "c1", "c2"],
+        )
+        target_list = []
+        kwarg_list = []
+        pc.map(map_auxiliar, "mean", target_list=target_list, kwarg_list=kwarg_list)
+        assert len(target_list) == 6
+        assert [kwargs["color"] for kwargs in kwarg_list] == [
+            "c0", "c0", "c1", "c1", "c2", "c2"
+        ]
 
 class TestFacetMap:
     def test_string_function(self, dataset):


### PR DESCRIPTION
Fixes arviz-devs/arviz-plots#551.
Broader context: arviz-devs/arviz#2602 (hierarchical model support).

Coordinate-based aesthetics (added in #241) fail when the coordinate's dimension is also used for faceting: `dim_to_idx` substitutes the dimension in `xarray_sel_iter`, so iteration collapses to the coordinate's granularity while `viz["plot"]` stays at the dimension's, and `get_target` returns multiple axes.

Removing the substitution outright breaks 33 `plot_parallel` tests, which rely on it to coarsen iteration so `label` stays inside `da` for `multiple_lines`. Restricting it by `facet_dims` alone was still insufficient — `plot_ridge` pins granularity through the `y` aesthetic rather than through faceting. Hence the two-clause condition.

`sel` is then augmented with the coordinate value so `get_target` resolves on the dimension and `get_aes_kwargs` on the coordinate; `sel_subset` routes each appropriately.

Test suite unchanged: 71 pre-existing failures before and after (unrelated `pit_dim` / `BF01` issues), plus the two new tests.

I also confirmed behaviour though manual trial in calling plots with aesthetics using coordinate ags. 