### PR TITLE
Update warning/error functions in `src/arviz_plots/plots/utils_plot_types.py`

### DIFF
--- a/src/arviz_plots/plots/utils_plot_types.py
+++ b/src/arviz_plots/plots/utils_plot_types.py
@@ -10,44 +10,46 @@ def warn_if_binary(observed_dist, predictive_dist):
     for dist, name in zip([observed_dist, predictive_dist], ["observed", "predictive"]):
         if dist is None:
             continue
-
         binary_vars = []
         for var in dist.data_vars:
             if np.isclose(dist[var].values, 0).all() or np.isclose(dist[var].values, 1).all():
                 binary_vars.append(var)
-
         if binary_vars:
             warnings.warn(
                 f"Variables {', '.join(binary_vars)} in '{name}' look binary. "
                 "For binary outcomes, plot_ppc_pava may be more appropriate.",
+                UserWarning,
                 stacklevel=2,
             )
 
 
 def warn_if_discrete(observed_dist, predictive_dist, kind):
     """Warn if data is discrete."""
-    observed_discrete, predictive_discrete = get_discrete_flags(observed_dist, predictive_dist)
-
-    if any(predictive_discrete + observed_discrete) and kind != "ecdf":
-        warnings.warn(
-            "Detected at least one discrete variable.\n"
-            "Consider using plot_ppc variants specific for discrete data, "
-            "such as plot_ppc_pava or plot_ppc_rootogram.",
-            UserWarning,
-            stacklevel=2,
-        )
+    for dist, name in zip([observed_dist, predictive_dist], ["observed", "predictive"]):
+        discrete_flags = get_discrete_flags(dist)
+        discrete_vars = [name for name, flag in discrete_flags.items() if flag]
+        if discrete_vars and kind != "ecdf":
+            warnings.warn(
+                f"Variables {', '.join(discrete_vars)} in '{name}' look discrete.\n"
+                "Consider using plot_ppc variants specific for discrete data, "
+                "such as plot_ppc_pava or plot_ppc_rootogram.",
+                UserWarning,
+                stacklevel=2,
+            )
 
 
 def raise_if_continuous(observed_dist, predictive_dist):
     """Raise error if data is continuous."""
-    observed_discrete, predictive_discrete = get_discrete_flags(observed_dist, predictive_dist)
-    if not all(predictive_discrete + observed_discrete):
-        raise ValueError(
-            "Detected at least one continuous variable.\n"
-            "This function only works for discrete data.\n"
-            "Consider using other functions such as plot_ppc_dist\n"
-            "plot_ppc_pit, or plot_ppc_tstat.",
-        )
+    for dist, name in zip([observed_dist, predictive_dist], ["observed", "predictive"]):
+        discrete_flags = get_discrete_flags(dist)
+        continuous_vars = [name for name, flag in discrete_flags.items() if not flag]
+        if continuous_vars:
+            raise ValueError(
+                f"Variables {', '.join(continuous_vars)} in '{name}' are continuous.\n"
+                "This function only works for discrete data.\n"
+                "Consider using other functions such as plot_ppc_dist\n"
+                "plot_ppc_pit, or plot_ppc_tstat.",
+            )
 
 
 def warn_if_prior_predictive(group):
@@ -61,17 +63,10 @@ def warn_if_prior_predictive(group):
         )
 
 
-def get_discrete_flags(observed_dist, predictive_dist):
-    """Get list of discrete flags for observed and predictive distributions."""
-    predictive_discrete = [
-        predictive_dist[var].values.dtype.kind == "i" for var in predictive_dist.data_vars
-    ]
-
-    if observed_dist is not None:
-        observed_discrete = [
-            observed_dist[var].values.dtype.kind == "i" for var in observed_dist.data_vars
-        ]
-    else:
-        observed_discrete = []
-
-    return observed_discrete, predictive_discrete
+def get_discrete_flags(group):
+    """Get a name-flag mapping to indicate which variables are discrete."""
+    flags = {}
+    if group is not None:
+        for var in group.data_vars:
+            flags[var] = group[var].values.dtype.kind == "i"
+    return flags

--- a/src/arviz_plots/plots/utils_plot_types.py
+++ b/src/arviz_plots/plots/utils_plot_types.py
@@ -7,12 +7,11 @@ import numpy as np
 
 def warn_if_binary(observed_dist, predictive_dist):
     """Warn if data is binary."""
-    for dist, name in zip([observed_dist, predictive_dist], ["observed", "predictive"]):
+    for dist, name in zip([observed_dist, predictive_dist], ["observed_data", "predictive"]):
         if dist is None:
             continue
         binary_vars = [
-            var for var, da in dist.items()
-            if (np.isclose(da, 0).all() | np.isclose(da, 1)).all()
+            var for var, da in dist.items() if (np.isclose(da, 0) | np.isclose(da, 1)).all()
         ]
         if binary_vars:
             warnings.warn(

--- a/src/arviz_plots/plots/utils_plot_types.py
+++ b/src/arviz_plots/plots/utils_plot_types.py
@@ -10,10 +10,10 @@ def warn_if_binary(observed_dist, predictive_dist):
     for dist, name in zip([observed_dist, predictive_dist], ["observed", "predictive"]):
         if dist is None:
             continue
-        binary_vars = []
-        for var in dist.data_vars:
-            if np.isclose(dist[var].values, 0).all() or np.isclose(dist[var].values, 1).all():
-                binary_vars.append(var)
+        binary_vars = [
+            var for var, da in dist.items()
+            if np.isclose(da, 0).all() or np.isclose(da, 1).all()
+        ]
         if binary_vars:
             warnings.warn(
                 f"Variables {', '.join(binary_vars)} in '{name}' look binary. "

--- a/src/arviz_plots/plots/utils_plot_types.py
+++ b/src/arviz_plots/plots/utils_plot_types.py
@@ -12,7 +12,7 @@ def warn_if_binary(observed_dist, predictive_dist):
             continue
         binary_vars = [
             var for var, da in dist.items()
-            if np.isclose(da, 0).all() or np.isclose(da, 1).all()
+            if (np.isclose(da, 0).all() | np.isclose(da, 1)).all()
         ]
         if binary_vars:
             warnings.warn(

--- a/src/arviz_plots/plots/utils_plot_types.py
+++ b/src/arviz_plots/plots/utils_plot_types.py
@@ -11,13 +11,15 @@ def warn_if_binary(observed_dist, predictive_dist):
         if dist is None:
             continue
 
-        if any(
-            (np.isclose(dist[var].values, 0) | np.isclose(dist[var].values, 1)).all()
-            for var in dist.data_vars
-        ):
+        binary_vars = []
+        for var in dist.data_vars:
+            if np.isclose(dist[var].values, 0).all() or np.isclose(dist[var].values, 1).all():
+                binary_vars.append(var)
+
+        if binary_vars:
             warnings.warn(
-                f"The {name} data looks binary. For binary outcomes, "
-                "plot_ppc_pava may be more appropriate.",
+                f"Variables {', '.join(binary_vars)} in '{name}' look binary. "
+                "For binary outcomes, plot_ppc_pava may be more appropriate.",
                 stacklevel=2,
             )
 

--- a/src/arviz_plots/plots/utils_plot_types.py
+++ b/src/arviz_plots/plots/utils_plot_types.py
@@ -10,7 +10,11 @@ def warn_if_binary(observed_dist, predictive_dist):
     for dist, name in zip([observed_dist, predictive_dist], ["observed", "predictive"]):
         if dist is None:
             continue
-        if any(set(np.unique(dist[var].values)).issubset({0, 1}) for var in dist.data_vars):
+
+        if any(
+            (np.isclose(dist[var].values, 0) | np.isclose(dist[var].values, 1)).all()
+            for var in dist.data_vars
+        ):
             warnings.warn(
                 f"The {name} data looks binary. For binary outcomes, "
                 "plot_ppc_pava may be more appropriate.",

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -898,7 +898,7 @@ class TestPlots:  # pylint: disable=too-many-public-methods
         assert "y" in pc.viz["plot"]
 
     def test_plot_ppc_rootogram_continuous_error(self, datatree, backend):
-        with pytest.raises(ValueError, match="Detected at least one continuous variable"):
+        with pytest.raises(ValueError, match="This function only works for discrete data"):
             plot_ppc_rootogram(datatree, backend=backend)
 
     @pytest.mark.parametrize("kind", ["kde", "ecdf", "hist", "dot"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ from arviz_plots.plots.utils import (
     set_grid_layout,
     set_wrap_layout,
 )
+from arviz_plots.plots.utils_plot_types import warn_if_binary
 
 
 class TestUtils:
@@ -271,3 +272,8 @@ class TestUtils:
         assert set(density.data_vars) == {"y_obs", "y_scalar"}
         assert density["y_obs"].attrs["kind"] == "kde"
         assert density["y_scalar"].attrs["kind"] == "kde"
+
+
+def test_warn_if_binary(datatree_binary):
+    with pytest.warns(UserWarning, match="Variables y in 'observed_data' look binary"):
+        warn_if_binary(datatree_binary["observed_data"].dataset, None)


### PR DESCRIPTION
Doing `np.unique` and `set` on very large arrays can take some time and space.
It's cheaper to check for approximate equality between the arrays and the values of interest.

At the same time, I am updating the rest of warning/error functions in the module to raise similar messages, including the name of the dataset and the variables.